### PR TITLE
Support for Perforce readonly file attribute

### DIFF
--- a/Editor/Steamworks.NET/RedistCopy.cs
+++ b/Editor/Steamworks.NET/RedistCopy.cs
@@ -31,6 +31,7 @@ public class RedistCopy {
 			string strFileDest = Path.Combine(Path.Combine(Path.GetDirectoryName(pathToBuiltProject), strProjectName + dir), "controller.vdf");
 
 			File.Copy(controllerCfg, strFileDest);
+			File.SetAttributes(strFileDest, File.GetAttributes(strFileDest) & ~FileAttributes.ReadOnly);
 
 			if (!File.Exists(strFileDest)) {
 				Debug.LogWarning("[Steamworks.NET] Could not copy controller.vdf into the built project. File.Copy() Failed. Place controller.vdf from the Steamworks SDK in the output dir manually.");
@@ -60,6 +61,7 @@ public class RedistCopy {
 		}
 
 		File.Copy(strSource, strFileDest, true);
+		File.SetAttributes(strFileDest, File.GetAttributes(strFileDest) & ~FileAttributes.ReadOnly);
 
 		if (!File.Exists(strFileDest)) {
 			Debug.LogWarning(string.Format("[Steamworks.NET] Could not copy {0} into the built project. File.Copy() Failed. Place {0} from the redist folder into the output dir manually.", filename));

--- a/Editor/Steamworks.NET/RedistInstall.cs
+++ b/Editor/Steamworks.NET/RedistInstall.cs
@@ -43,6 +43,7 @@ public class RedistInstall {
 		}
 
 		File.Copy(strSource, strDest, true);
+		File.SetAttributes(strDest, File.GetAttributes(strDest) & ~FileAttributes.ReadOnly);
 
 		if (File.Exists(strDest)) {
 			Debug.Log(string.Format("[Steamworks.NET] Successfully copied {0} into the project root. Please relaunch Unity.", filename));


### PR DESCRIPTION
When working under Perforce version control, by default, all files have the readonly attribute. To prevent UnauthorizedAccessException, I modified RedistCopy.cs and RedistInstall.cs to remove the readonly attribute from destination files after copying.
