### PR TITLE
Fix compile errors on non-Standalone platforms

### DIFF
--- a/Editor/Steamworks.NET/RedistCopy.cs
+++ b/Editor/Steamworks.NET/RedistCopy.cs
@@ -2,6 +2,12 @@
 // Copyright (c) 2013-2018 Riley Labrecque
 // Please see the included LICENSE.txt for additional information.
 
+#if UNITY_ANDROID || UNITY_IOS || UNITY_TIZEN || UNITY_TVOS || UNITY_WEBGL || UNITY_WSA || UNITY_PS4 || UNITY_WII || UNITY_XBOXONE
+#define DISABLESTEAMWORKS
+#endif
+
+#if !DISABLESTEAMWORKS
+
 // Add 'DISABLEREDISTCOPY' to your custom platform defines to disable automatic copying!
 #if UNITY_5_3_OR_NEWER
 	#define DISABLEREDISTCOPY
@@ -112,3 +118,5 @@ public class RedistCopy {
 		}
 	}
 }
+
+#endif // !DISABLESTEAMWORKS


### PR DESCRIPTION
Without this PR, the following compile error occurs on all non-Standalone platforms: `Assets/Editor/Steamworks.NET/RedistCopy.cs(19,7): error CS0246: The type or namespace name 'Steamworks' could not be found. Are you missing an assembly reference?`