### PR TITLE
Unity 2019.2 no longer supports Linux 32 Bit

### DIFF
--- a/Editor/Steamworks.NET/RedistCopy.cs
+++ b/Editor/Steamworks.NET/RedistCopy.cs
@@ -3,7 +3,7 @@
 // Please see the included LICENSE.txt for additional information.
 
 #if UNITY_ANDROID || UNITY_IOS || UNITY_TIZEN || UNITY_TVOS || UNITY_WEBGL || UNITY_WSA || UNITY_PS4 || UNITY_WII || UNITY_XBOXONE || UNITY_SWITCH
-#define DISABLESTEAMWORKS
+	#define DISABLESTEAMWORKS
 #endif
 
 #if !DISABLESTEAMWORKS
@@ -19,104 +19,120 @@ using UnityEditor.Callbacks;
 using Steamworks;
 using System.IO;
 
-public class RedistCopy {
-	[PostProcessBuild]
-	public static void OnPostprocessBuild(BuildTarget target, string pathToBuiltProject) {
-		string baseDir;
-		string pluginsDir;
-		switch(target)
-		{
-		case BuildTarget.StandaloneWindows:
-		case BuildTarget.StandaloneWindows64:
-			baseDir = Path.Combine(Path.GetDirectoryName(pathToBuiltProject), Path.GetFileNameWithoutExtension(pathToBuiltProject) + "_Data");
-			pluginsDir = Path.Combine(baseDir, "Plugins");
-			break;
-		case BuildTarget.StandaloneLinux:
-			baseDir = Path.Combine(Path.GetDirectoryName(pathToBuiltProject), Path.GetFileNameWithoutExtension(pathToBuiltProject) + "_Data");
-			pluginsDir = Path.Combine(Path.Combine(baseDir, "Plugins"), "x86");
-			break;
-		case BuildTarget.StandaloneLinux64:
-		case BuildTarget.StandaloneLinuxUniversal:
-			baseDir = Path.Combine(Path.GetDirectoryName(pathToBuiltProject), Path.GetFileNameWithoutExtension(pathToBuiltProject) + "_Data");
-			pluginsDir = Path.Combine(Path.Combine(baseDir, "Plugins"), "x86_64");
-			break;
-#if UNITY_2017_3_OR_NEWER
-		case BuildTarget.StandaloneOSX:
-#else
-		case BuildTarget.StandaloneOSXIntel:
-		case BuildTarget.StandaloneOSXIntel64:
-		case BuildTarget.StandaloneOSXUniversal:
+public class RedistCopy
+{
+    [PostProcessBuild]
+    public static void OnPostprocessBuild(BuildTarget target, string pathToBuiltProject)
+    {
+        string baseDir;
+        string pluginsDir;
+        switch (target)
+        {
+            case BuildTarget.StandaloneWindows:
+            case BuildTarget.StandaloneWindows64:
+                baseDir = Path.Combine(Path.GetDirectoryName(pathToBuiltProject), Path.GetFileNameWithoutExtension(pathToBuiltProject) + "_Data");
+                pluginsDir = Path.Combine(baseDir, "Plugins");
+                break;
+#if !UNITY_2019_2_OR_NEWER
+            case BuildTarget.StandaloneLinux:
+                baseDir = Path.Combine(Path.GetDirectoryName(pathToBuiltProject), Path.GetFileNameWithoutExtension(pathToBuiltProject) + "_Data");
+                pluginsDir = Path.Combine(Path.Combine(baseDir, "Plugins"), "x86");
+                break;
 #endif
-			baseDir = Path.Combine(Path.GetDirectoryName(pathToBuiltProject), Path.GetFileNameWithoutExtension(pathToBuiltProject) + ".app");
-			baseDir = Path.Combine(baseDir, "Contents");
-			pluginsDir = Path.Combine(baseDir, "Plugins");
-			break;
-		default:
-			return;
-		}
+            case BuildTarget.StandaloneLinux64:
+#if !UNITY_2019_2_OR_NEWER
+            case BuildTarget.StandaloneLinuxUniversal:
+                baseDir = Path.Combine(Path.GetDirectoryName(pathToBuiltProject), Path.GetFileNameWithoutExtension(pathToBuiltProject) + "_Data");
+                pluginsDir = Path.Combine(Path.Combine(baseDir, "Plugins"), "x86_64");
+                break;
+#endif
+#if UNITY_2017_3_OR_NEWER
+            case BuildTarget.StandaloneOSX:
+#else
+            case BuildTarget.StandaloneOSXIntel:
+            case BuildTarget.StandaloneOSXIntel64:
+            case BuildTarget.StandaloneOSXUniversal:
+#endif
+                baseDir = Path.Combine(Path.GetDirectoryName(pathToBuiltProject), Path.GetFileNameWithoutExtension(pathToBuiltProject) + ".app");
+                baseDir = Path.Combine(baseDir, "Contents");
+                pluginsDir = Path.Combine(baseDir, "Plugins");
+                break;
+            default:
+                return;
+        }
 
-		string[] DebugInfo = {
-			"Steamworks.NET created by Riley Labrecque",
-			"http://steamworks.github.io",
-			"",
-			"Steamworks.NET Version: " + Steamworks.Version.SteamworksNETVersion,
-			"Steamworks SDK Version: " + Steamworks.Version.SteamworksSDKVersion,
-			"Steam API DLL Version:  " + Steamworks.Version.SteamAPIDLLVersion,
-			"Steam API DLL Size:     " + Steamworks.Version.SteamAPIDLLSize,
-			"Steam API64 DLL Size:   " + Steamworks.Version.SteamAPI64DLLSize,
-			""
-		};
-		File.WriteAllLines(Path.Combine(pluginsDir, "Steamworks.NET.txt"), DebugInfo);
+        string[] DebugInfo = {
+            "Steamworks.NET created by Riley Labrecque",
+            "http://steamworks.github.io",
+            "",
+            "Steamworks.NET Version: " + Steamworks.Version.SteamworksNETVersion,
+            "Steamworks SDK Version: " + Steamworks.Version.SteamworksSDKVersion,
+            "Steam API DLL Version:  " + Steamworks.Version.SteamAPIDLLVersion,
+            "Steam API DLL Size:     " + Steamworks.Version.SteamAPIDLLSize,
+            "Steam API64 DLL Size:   " + Steamworks.Version.SteamAPI64DLLSize,
+            ""
+        };
+        File.WriteAllLines(Path.Combine(pluginsDir, "Steamworks.NET.txt"), DebugInfo);
 
 #if !DISABLEREDISTCOPY
-		if (target == BuildTarget.StandaloneWindows64) {
-			CopyFile("steam_api64.dll", "steam_api64.dll", "Assets/Plugins/x86_64", pathToBuiltProject);
-		}
-		else if (target == BuildTarget.StandaloneWindows) {
-			CopyFile("steam_api.dll", "steam_api.dll", "Assets/Plugins/x86", pathToBuiltProject);
-		}
+        if (target == BuildTarget.StandaloneWindows64)
+        {
+            CopyFile("steam_api64.dll", "steam_api64.dll", "Assets/Plugins/x86_64", pathToBuiltProject);
+        }
+        else if (target == BuildTarget.StandaloneWindows)
+        {
+            CopyFile("steam_api.dll", "steam_api.dll", "Assets/Plugins/x86", pathToBuiltProject);
+        }
 
-		string controllerCfg = Path.Combine(Application.dataPath, "controller.vdf");
-		if (File.Exists(controllerCfg)) {
-			string strFileDest = Path.Combine(baseDir, "controller.vdf");
+        string controllerCfg = Path.Combine(Application.dataPath, "controller.vdf");
+        if (File.Exists(controllerCfg))
+        {
+            string strFileDest = Path.Combine(baseDir, "controller.vdf");
 
-			File.Copy(controllerCfg, strFileDest);
-			File.SetAttributes(strFileDest, File.GetAttributes(strFileDest) & ~FileAttributes.ReadOnly);
+            File.Copy(controllerCfg, strFileDest);
+            File.SetAttributes(strFileDest, File.GetAttributes(strFileDest) & ~FileAttributes.ReadOnly);
 
-			if (!File.Exists(strFileDest)) {
-				Debug.LogWarning("[Steamworks.NET] Could not copy controller.vdf into the built project. File.Copy() Failed. Place controller.vdf from the Steamworks SDK in the output dir manually.");
-			}
-		}
+            if (!File.Exists(strFileDest))
+            {
+                Debug.LogWarning("[Steamworks.NET] Could not copy controller.vdf into the built project. File.Copy() Failed. Place controller.vdf from the Steamworks SDK in the output dir manually.");
+            }
+        }
 #endif
-	}
+    }
 
-	static void CopyFile(string filename, string outputfilename, string pathToFile, string pathToBuiltProject) {
-		string strCWD = Directory.GetCurrentDirectory();
-		string strSource = Path.Combine(Path.Combine(strCWD, pathToFile), filename);
-		string strFileDest = Path.Combine(Path.GetDirectoryName(pathToBuiltProject), outputfilename);
+    static void CopyFile(string filename, string outputfilename, string pathToFile, string pathToBuiltProject)
+    {
+        string strCWD = Directory.GetCurrentDirectory();
+        string strSource = Path.Combine(Path.Combine(strCWD, pathToFile), filename);
+        string strFileDest = Path.Combine(Path.GetDirectoryName(pathToBuiltProject), outputfilename);
 
-		if (!File.Exists(strSource)) {
-			Debug.LogWarning(string.Format("[Steamworks.NET] Could not copy {0} into the project root. {0} could not be found in '{1}'. Place {0} from the redist into the project root manually.", filename, pathToFile));
-			return;
-		}
+        if (!File.Exists(strSource))
+        {
+            Debug.LogWarning(string.Format("[Steamworks.NET] Could not copy {0} into the project root. {0} could not be found in '{1}'. Place {0} from the redist into the project root manually.", filename, pathToFile));
+            return;
+        }
 
-		if (File.Exists(strFileDest)) {
-			if (File.GetLastWriteTime(strSource) == File.GetLastWriteTime(strFileDest)) {
-				FileInfo fInfo = new FileInfo(strSource);
-				FileInfo fInfo2 = new FileInfo(strFileDest);
-				if (fInfo.Length == fInfo2.Length) {
-					return;
-				}
-			}
-		}
+        if (File.Exists(strFileDest))
+        {
+            if (File.GetLastWriteTime(strSource) == File.GetLastWriteTime(strFileDest))
+            {
+                FileInfo fInfo = new FileInfo(strSource);
+                FileInfo fInfo2 = new FileInfo(strFileDest);
+                if (fInfo.Length == fInfo2.Length)
+                {
+                    return;
+                }
+            }
+        }
 
-		File.Copy(strSource, strFileDest, true);
-		File.SetAttributes(strFileDest, File.GetAttributes(strFileDest) & ~FileAttributes.ReadOnly);
+        File.Copy(strSource, strFileDest, true);
+        File.SetAttributes(strFileDest, File.GetAttributes(strFileDest) & ~FileAttributes.ReadOnly);
 
-		if (!File.Exists(strFileDest)) {
-			Debug.LogWarning(string.Format("[Steamworks.NET] Could not copy {0} into the built project. File.Copy() Failed. Place {0} from the redist folder into the output dir manually.", filename));
-		}
-	}
+        if (!File.Exists(strFileDest))
+        {
+            Debug.LogWarning(string.Format("[Steamworks.NET] Could not copy {0} into the built project. File.Copy() Failed. Place {0} from the redist folder into the output dir manually.", filename));
+        }
+    }
 }
 
 #endif // !DISABLESTEAMWORKS

--- a/Editor/Steamworks.NET/RedistInstall.cs
+++ b/Editor/Steamworks.NET/RedistInstall.cs
@@ -11,64 +11,74 @@ using System.IO;
 
 // This copys various files into their required locations when Unity is launched to make installation a breeze.
 [InitializeOnLoad]
-public class RedistInstall {
-	static RedistInstall() {
-		CopyFile("Assets/Plugins/Steamworks.NET/redist", "steam_appid.txt", false);
+public class RedistInstall
+{
+    static RedistInstall()
+    {
+        CopyFile("Assets/Plugins/Steamworks.NET/redist", "steam_appid.txt", false);
 
-		// We only need to copy the dll into the project root on <= Unity 5.0
+        // We only need to copy the dll into the project root on <= Unity 5.0
 #if UNITY_EDITOR_WIN && (UNITY_4_7 || UNITY_5_0)
-	#if UNITY_EDITOR_64
+#if UNITY_EDITOR_64
 		CopyFile("Assets/Plugins/x86_64", "steam_api64.dll", true);
-	#else
+#else
 		CopyFile("Assets/Plugins/x86", "steam_api.dll", true);
-	#endif
+#endif
 #endif
 
 #if UNITY_5 || UNITY_2017
-	#if !DISABLEPLATFORMSETTINGS
+#if !DISABLEPLATFORMSETTINGS
 		SetPlatformSettings();
-	#endif
 #endif
-	}
+#endif
+    }
 
-	static void CopyFile(string path, string filename, bool bCheckDifference) {
-		string strCWD = Directory.GetCurrentDirectory();
-		string strSource = Path.Combine(Path.Combine(strCWD, path), filename);
-		string strDest = Path.Combine(strCWD, filename);
+    static void CopyFile(string path, string filename, bool bCheckDifference)
+    {
+        string strCWD = Directory.GetCurrentDirectory();
+        string strSource = Path.Combine(Path.Combine(strCWD, path), filename);
+        string strDest = Path.Combine(strCWD, filename);
 
-		if (!File.Exists(strSource)) {
-			Debug.LogWarning(string.Format("[Steamworks.NET] Could not copy {0} into the project root. {0} could not be found in '{1}'. Place {0} from the Steamworks SDK in the project root manually.", filename, Path.Combine(strCWD, path)));
-			return;
-		}
+        if (!File.Exists(strSource))
+        {
+            Debug.LogWarning(string.Format("[Steamworks.NET] Could not copy {0} into the project root. {0} could not be found in '{1}'. Place {0} from the Steamworks SDK in the project root manually.", filename, Path.Combine(strCWD, path)));
+            return;
+        }
 
-		if (File.Exists(strDest)) {
-			if (!bCheckDifference)
-				return;
+        if (File.Exists(strDest))
+        {
+            if (!bCheckDifference)
+                return;
 
-			if (File.GetLastWriteTime(strSource) == File.GetLastWriteTime(strDest)) {
-				FileInfo fInfo = new FileInfo(strSource);
-				FileInfo fInfo2 = new FileInfo(strDest);
-				if (fInfo.Length == fInfo2.Length) {
-					return;
-				}
-			}
+            if (File.GetLastWriteTime(strSource) == File.GetLastWriteTime(strDest))
+            {
+                FileInfo fInfo = new FileInfo(strSource);
+                FileInfo fInfo2 = new FileInfo(strDest);
+                if (fInfo.Length == fInfo2.Length)
+                {
+                    return;
+                }
+            }
 
-			Debug.Log(string.Format("[Steamworks.NET] {0} in the project root differs from the Steamworks.NET redistributable. Updating.... Please relaunch Unity.", filename));
-		}
-		else {
-			Debug.Log(string.Format("[Steamworks.NET] {0} is not present in the project root. Copying...", filename));
-		}
+            Debug.Log(string.Format("[Steamworks.NET] {0} in the project root differs from the Steamworks.NET redistributable. Updating.... Please relaunch Unity.", filename));
+        }
+        else
+        {
+            Debug.Log(string.Format("[Steamworks.NET] {0} is not present in the project root. Copying...", filename));
+        }
 
-		File.Copy(strSource, strDest, true);
-		File.SetAttributes(strDest, File.GetAttributes(strDest) & ~FileAttributes.ReadOnly);
+        File.Copy(strSource, strDest, true);
+        File.SetAttributes(strDest, File.GetAttributes(strDest) & ~FileAttributes.ReadOnly);
 
-		if (File.Exists(strDest)) {
-			Debug.Log(string.Format("[Steamworks.NET] Successfully copied {0} into the project root. Please relaunch Unity.", filename));
-		}
-		else {
-			Debug.LogWarning(string.Format("[Steamworks.NET] Could not copy {0} into the project root. File.Copy() Failed. Please copy {0} into the project root manually.", Path.Combine(path, filename)));
-		}
-	}
+        if (File.Exists(strDest))
+        {
+            Debug.Log(string.Format("[Steamworks.NET] Successfully copied {0} into the project root. Please relaunch Unity.", filename));
+        }
+        else
+        {
+            Debug.LogWarning(string.Format("[Steamworks.NET] Could not copy {0} into the project root. File.Copy() Failed. Please copy {0} into the project root manually.", Path.Combine(path, filename)));
+        }
+    }
 
 #if UNITY_5 || UNITY_2017 || UNITY_2017_1_OR_NEWER
 	static void SetPlatformSettings() {
@@ -96,10 +106,12 @@ public class RedistInstall {
 						didUpdate |= ResetPluginSettings(plugin, "x86_64", "Linux");
 						didUpdate |= SetCompatibleWithLinux(plugin, BuildTarget.StandaloneLinux64);
 					}
+#if !UNITY_2019_2_OR_NEWER
 					else {
 						didUpdate |= ResetPluginSettings(plugin, "x86", "Linux");
 						didUpdate |= SetCompatibleWithLinux(plugin, BuildTarget.StandaloneLinux);
 					}
+#endif
 					break;
 				case "steam_api.dll":
 				case "steam_api64.dll":
@@ -170,9 +182,13 @@ public class RedistInstall {
 		didUpdate |= SetCompatibleWithPlatform(plugin, BuildTarget.StandaloneOSXUniversal, true);
 #endif
 
+#if !UNITY_2019_2_OR_NEWER
 		didUpdate |= SetCompatibleWithPlatform(plugin, BuildTarget.StandaloneLinux, false);
+#endif
 		didUpdate |= SetCompatibleWithPlatform(plugin, BuildTarget.StandaloneLinux64, false);
+#if !UNITY_2019_2_OR_NEWER
 		didUpdate |= SetCompatibleWithPlatform(plugin, BuildTarget.StandaloneLinuxUniversal, false);
+#endif
 		didUpdate |= SetCompatibleWithPlatform(plugin, BuildTarget.StandaloneWindows, false);
 		didUpdate |= SetCompatibleWithPlatform(plugin, BuildTarget.StandaloneWindows64, false);
 
@@ -182,7 +198,10 @@ public class RedistInstall {
 	static bool SetCompatibleWithLinux(PluginImporter plugin, BuildTarget platform) {
 		bool didUpdate = false;
 
-		if (platform == BuildTarget.StandaloneLinux) {
+#if UNITY_2019_2_OR_NEWER
+        didUpdate |= SetCompatibleWithPlatform(plugin, BuildTarget.StandaloneLinux64, true);
+#else
+        if (platform == BuildTarget.StandaloneLinux) {
 			didUpdate |= SetCompatibleWithPlatform(plugin, BuildTarget.StandaloneLinux, true);
 			didUpdate |= SetCompatibleWithPlatform(plugin, BuildTarget.StandaloneLinux64, false);
 		}
@@ -190,10 +209,11 @@ public class RedistInstall {
 			didUpdate |= SetCompatibleWithPlatform(plugin, BuildTarget.StandaloneLinux, false);
 			didUpdate |= SetCompatibleWithPlatform(plugin, BuildTarget.StandaloneLinux64, true);
 		}
-		didUpdate |= SetCompatibleWithPlatform(plugin, BuildTarget.StandaloneLinuxUniversal, true);
+        didUpdate |= SetCompatibleWithPlatform(plugin, BuildTarget.StandaloneLinuxUniversal, true);
+#endif
 
 #if UNITY_2017_3_OR_NEWER
-		didUpdate |= SetCompatibleWithPlatform(plugin, BuildTarget.StandaloneOSX, false);
+        didUpdate |= SetCompatibleWithPlatform(plugin, BuildTarget.StandaloneOSX, false);
 #else
 		didUpdate |= SetCompatibleWithPlatform(plugin, BuildTarget.StandaloneOSXIntel, false);
 		didUpdate |= SetCompatibleWithPlatform(plugin, BuildTarget.StandaloneOSXIntel64, false);
@@ -218,8 +238,10 @@ public class RedistInstall {
 		}
 
 		didUpdate |= SetCompatibleWithPlatform(plugin, BuildTarget.StandaloneLinux64, false);
+#if !UNITY_2019_2_OR_NEWER
 		didUpdate |= SetCompatibleWithPlatform(plugin, BuildTarget.StandaloneLinux, false);
 		didUpdate |= SetCompatibleWithPlatform(plugin, BuildTarget.StandaloneLinuxUniversal, false);
+#endif
 #if UNITY_2017_3_OR_NEWER
 		didUpdate |= SetCompatibleWithPlatform(plugin, BuildTarget.StandaloneOSX, false);
 #else
@@ -235,8 +257,10 @@ public class RedistInstall {
 		bool didUpdate = false;
 
 		didUpdate |= SetCompatibleWithPlatform(plugin, BuildTarget.StandaloneLinux64, false);
+#if !UNITY_2019_2_OR_NEWER
 		didUpdate |= SetCompatibleWithPlatform(plugin, BuildTarget.StandaloneLinux, false);
 		didUpdate |= SetCompatibleWithPlatform(plugin, BuildTarget.StandaloneLinuxUniversal, false);
+#endif
 #if UNITY_2017_3_OR_NEWER
 		didUpdate |= SetCompatibleWithPlatform(plugin, BuildTarget.StandaloneOSX, false);
 #else


### PR DESCRIPTION
It looks like Unity 2019.2 no longer supports Linux 32 bit.
Added some ifs to avoid warnings for invalid BuildTargets in Unity 2019.2 and newer.