### PR TITLE
Manual callback dispatch

### DIFF
--- a/Plugins/Steamworks.NET/CallbackDispatcher.cs
+++ b/Plugins/Steamworks.NET/CallbackDispatcher.cs
@@ -75,6 +75,17 @@ namespace Steamworks {
 				foreach (var iCallback in unusedICallbacks) {
 					m_registeredCallbacks.Remove(iCallback);
 				}
+
+				unusedICallbacks.Clear();
+
+				foreach (var pair in m_registeredGameServerCallbacks) {
+					if (pair.Value.Count == 0)
+						unusedICallbacks.Add(pair.Key);
+				}
+
+				foreach (var iCallback in unusedICallbacks) {
+					m_registeredGameServerCallbacks.Remove(iCallback);
+				}
 			}
 		}
 

--- a/Plugins/Steamworks.NET/CallbackDispatcher.cs
+++ b/Plugins/Steamworks.NET/CallbackDispatcher.cs
@@ -25,29 +25,8 @@
 	#error You need to define STEAMWORKS_WIN, or STEAMWORKS_LIN_OSX. Refer to the readme for more details.
 #endif
 
-// Unity 32bit Mono on Windows crashes with ThisCall/Cdecl for some reason, StdCall without the 'this' ptr is the only thing that works..?
-#if (UNITY_EDITOR_WIN && !UNITY_EDITOR_64) || (!UNITY_EDITOR && UNITY_STANDALONE_WIN && !UNITY_64)
-	#define STDCALL
-#elif STEAMWORKS_WIN
-	#define THISCALL
-#endif
-
-// Calling Conventions:
-// Unity x86 Windows        - StdCall (No this pointer)
-// Unity x86 Linux          - Cdecl
-// Unity x86 OSX            - Cdecl
-// Unity x64 Windows        - Cdecl
-// Unity x64 Linux          - Cdecl
-// Unity x64 OSX            - Cdecl
-// Microsoft x86 Windows    - ThisCall
-// Microsoft x64 Windows    - ThisCall
-// Mono x86 Linux           - Cdecl
-// Mono x86 OSX             - Cdecl
-// Mono x64 Linux           - Cdecl
-// Mono x64 OSX             - Cdecl
-// Mono on Windows is probably not supported.
-
 using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
 namespace Steamworks {
@@ -62,19 +41,139 @@ namespace Steamworks {
 			Console.WriteLine(e.Message);
 #endif
 		}
+
+		private static Dictionary<int, List<Callback>> m_registeredCallbacks = new Dictionary<int, List<Callback>>();
+		private static Dictionary<int, List<Callback>> m_registeredGameServerCallbacks = new Dictionary<int, List<Callback>>();
+		private static Dictionary<ulong, CallResult> m_registeredCallResults = new Dictionary<ulong, CallResult>();
+		private static List<ulong> m_dispatchedApiCalls = new List<ulong>();
+		private static object m_sync = new object();
+		private static CallbackMsg_t m_callbackMsg; // Preallocated
+		private static GCHandle m_pCallbackMsg;
+
+		public static bool IsInitialized { get; private set; }
+
+		internal static void Initialize() {
+			NativeMethods.SteamAPI_ManualDispatch_Init();
+			m_pCallbackMsg = GCHandle.Alloc(m_callbackMsg, GCHandleType.Pinned);
+			IsInitialized = true;
+		}
+
+		internal static void Shutdown() {
+			if (m_pCallbackMsg.IsAllocated)
+				m_pCallbackMsg.Free();
+			IsInitialized = false;
+		}
+
+		public static void Prune() {
+			List<int> unusedICallbacks = new List<int>();
+			lock (m_sync) {
+				foreach (var pair in m_registeredCallbacks) {
+					if (pair.Value.Count == 0)
+						unusedICallbacks.Add(pair.Key);
+				}
+
+				foreach (var iCallback in unusedICallbacks) {
+					m_registeredCallbacks.Remove(iCallback);
+				}
+			}
+		}
+
+		internal static void Register(Callback cb) {
+			int iCallback = CallbackIdentities.GetCallbackIdentity(cb.GetCallbackType());
+			var callbacksRegistry = cb.IsGameServer ? m_registeredGameServerCallbacks : m_registeredCallbacks;
+			lock (m_sync) {
+				List<Callback> callbacksList;
+				if (!callbacksRegistry.TryGetValue(iCallback, out callbacksList)) {
+					callbacksList = new List<Callback>();
+					callbacksRegistry.Add(iCallback, callbacksList);
+				}
+
+				callbacksList.Add(cb);
+			}
+		}
+
+		internal static void Register(SteamAPICall_t asyncCall, CallResult cr) {
+			lock (m_sync) {
+				// Dispatch goes to last CallResult the SteamAPICall_t is set on
+				m_registeredCallResults[(ulong)asyncCall] = cr;
+			}
+		}
+
+		internal static void Unregister(Callback cb) {
+			int iCallback = CallbackIdentities.GetCallbackIdentity(cb.GetCallbackType());
+			var callbacksRegistry = cb.IsGameServer ? m_registeredGameServerCallbacks : m_registeredCallbacks;
+			lock (m_sync) {
+				List<Callback> callbacksList;
+				if (callbacksRegistry.TryGetValue(iCallback, out var callbacksList)) {
+					callbacksList.Remove(cb);
+				}
+			}
+		}
+
+		internal static void Unregister(SteamAPICall_t asyncCall) {
+			lock (m_sync) {
+				m_registeredCallResults.Remove((ulong)asyncCall);
+			}
+		}
+
+		internal static void RunFrame(bool isGameServer) {
+			if (!IsInitialized) throw new InvalidOperationException("Callback dispatcher is not initialized.");
+
+			HSteamPipe hSteamPipe = (HSteamPipe)(isGameServer ? NativeMethods.SteamGameServer_GetHSteamPipe() : NativeMethods.SteamAPI_GetHSteamPipe());
+			NativeMethods.SteamAPI_ManualDispatch_RunFrame(hSteamPipe);
+			var callbacksRegistry = isGameServer ? m_registeredGameServerCallbacks : m_registeredCallbacks;
+			lock (m_sync) {
+				while (NativeMethods.SteamAPI_ManualDispatch_GetNextCallback(hSteamPipe, m_pCallbackMsg.AddrOfPinnedObject())) {
+					try {
+						// Check for dispatching API call results
+						if (m_callbackMsg.m_iCallback == SteamAPICallCompleted_t.k_iCallback) {
+							SteamAPICallCompleted_t callCompletedCb;
+							Marshal.PtrToStructure(m_callbackMsg.m_pubParam, callCompletedCb);
+							IntPtr pTmpCallResult = Marshal.AllocHGlobal(callCompletedCb.m_cubParam);
+							bool bFailed;
+							try {
+								if (NativeMethods.SteamAPI_ManualDispatch_GetAPICallResult(hSteamPipe, callCompletedCb.m_hAsyncCall, pTmpCallResult, callCompletedCb.m_cubParam, callCompletedCb.m_iCallback, out bFailed)) {
+									if (m_registeredCallResults.TryGetValue((ulong)callCompletedCb.m_hAsyncCall, out CallResult cr)) {
+										cr.OnRunCallResult(pTmpCallResult, bFailed, (ulong)callCompletedCb.m_hAsyncCall);
+									}
+								}
+							} finally {
+								Marshal.FreeHGlobal(pTmpCallResult);
+								m_dispatchedApiCalls.Add((ulong)callCompletedCb.m_hAsyncCall);
+							}
+						} else {
+							if (callbacksRegistry.TryGetValue(m_callbackMsg.m_iCallback, out var callbacks)) {
+								foreach (var callback in callbacks) {
+									callback.OnRunCallback(m_callbackMsg.m_pubParam);
+								}
+							}
+						}
+					} catch (Exception e) {
+						ExceptionHandler(e);
+					} finally {
+						NativeMethods.SteamAPI_ManualDispatch_FreeLastCallback(hSteamPipe);
+						foreach (var call in m_dispatchedApiCalls) {
+							m_registeredCallResults.Remove(call);
+						}
+						m_dispatchedApiCalls.Clear();
+					}
+				}
+			}
+		}
 	}
 
-	public sealed class Callback<T> : IDisposable {
-		private CCallbackBaseVTable m_CallbackBaseVTable;
-		private IntPtr m_pVTable = IntPtr.Zero;
-		private CCallbackBase m_CCallbackBase;
-		private GCHandle m_pCCallbackBase;
+	public abstract class Callback {
+		public abstract bool IsGameServer { get; }
+		internal abstract Type GetCallbackType();
+		internal abstract void OnRunCallback(IntPtr pvParam);
+	}
 
+	public sealed class Callback<T> : Callback, IDisposable {
 		public delegate void DispatchDelegate(T param);
 		private event DispatchDelegate m_Func;
 
 		private bool m_bGameServer;
-		private readonly int m_size = Marshal.SizeOf(typeof(T));
+		private bool m_bIsRegistered;
 
 		private bool m_bDisposed = false;
 
@@ -98,7 +197,6 @@ namespace Steamworks {
 
 		public Callback(DispatchDelegate func, bool bGameServer = false) {
 			m_bGameServer = bGameServer;
-			BuildCCallbackBase();
 			Register(func);
 		}
 
@@ -115,14 +213,6 @@ namespace Steamworks {
 
 			Unregister();
 
-			if (m_pVTable != IntPtr.Zero) {
-				Marshal.FreeHGlobal(m_pVTable);
-			}
-
-			if (m_pCCallbackBase.IsAllocated) {
-				m_pCCallbackBase.Free();
-			}
-
 			m_bDisposed = true;
 		}
 
@@ -132,34 +222,28 @@ namespace Steamworks {
 				throw new Exception("Callback function must not be null.");
 			}
 
-			if ((m_CCallbackBase.m_nCallbackFlags & CCallbackBase.k_ECallbackFlagsRegistered) == CCallbackBase.k_ECallbackFlagsRegistered) {
+			if (m_bIsRegistered) {
 				Unregister();
-			}
-
-			if (m_bGameServer) {
-				SetGameserverFlag();
 			}
 
 			m_Func = func;
 
-			// k_ECallbackFlagsRegistered is set by SteamAPI_RegisterCallback.
-			NativeMethods.SteamAPI_RegisterCallback(m_pCCallbackBase.AddrOfPinnedObject(), CallbackIdentities.GetCallbackIdentity(typeof(T)));
+			CallbackDispatcher.Register(this);
+			m_bIsRegistered = true;
 		}
 
 		public void Unregister() {
-			// k_ECallbackFlagsRegistered is removed by SteamAPI_UnregisterCallback.
-			NativeMethods.SteamAPI_UnregisterCallback(m_pCCallbackBase.AddrOfPinnedObject());
+			CallbackDispatcher.Unregister(this);
+			m_bIsRegistered = false;
 		}
 
-		public void SetGameserverFlag() {
-			m_CCallbackBase.m_nCallbackFlags |= CCallbackBase.k_ECallbackFlagsGameServer;
+		public override bool IsGameServer => m_bIsRegistered;
+
+		internal override Type GetCallbackType() {
+			return typeof(T);
 		}
 
-		private void OnRunCallback(
-#if !STDCALL
-			IntPtr thisptr,
-#endif
-			IntPtr pvParam) {
+		internal override void OnRunCallback(IntPtr pvParam) {
 			try {
 				m_Func((T)Marshal.PtrToStructure(pvParam, typeof(T)));
 			}
@@ -167,61 +251,19 @@ namespace Steamworks {
 				CallbackDispatcher.ExceptionHandler(e);
 			}
 		}
+	}
 
-		// Shouldn't ever get called here, but this is what C++ Steamworks does!
-		private void OnRunCallResult(
-#if !STDCALL
-			IntPtr thisptr,
-#endif
-			IntPtr pvParam, bool bFailed, ulong hSteamAPICall) {
-			try { 
-				m_Func((T)Marshal.PtrToStructure(pvParam, typeof(T)));
-			}
-			catch (Exception e) {
-				CallbackDispatcher.ExceptionHandler(e);
-			}
-		}
-
-		private int OnGetCallbackSizeBytes(
-#if !STDCALL
-			IntPtr thisptr
-#endif
-			) {
-			return m_size;
-		}
-
-		// Steamworks.NET Specific
-		private void BuildCCallbackBase() {
-			m_CallbackBaseVTable = new CCallbackBaseVTable() {
-				m_RunCallResult = OnRunCallResult,
-				m_RunCallback = OnRunCallback,
-				m_GetCallbackSizeBytes = OnGetCallbackSizeBytes
-			};
-			m_pVTable = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(CCallbackBaseVTable)));
-			Marshal.StructureToPtr(m_CallbackBaseVTable, m_pVTable, false);
-
-			m_CCallbackBase = new CCallbackBase() {
-				m_vfptr = m_pVTable,
-				m_nCallbackFlags = 0,
-				m_iCallback = CallbackIdentities.GetCallbackIdentity(typeof(T))
-			};
-			m_pCCallbackBase = GCHandle.Alloc(m_CCallbackBase, GCHandleType.Pinned);
-		}
+	public abstract class CallResult {
+		internal abstract Type GetCallbackType();
+		internal abstract void OnRunCallResult(IntPtr pvParam, bool bFailed, ulong hSteamAPICall);
 	}
 
 	public sealed class CallResult<T> : IDisposable {
-		private CCallbackBaseVTable m_CallbackBaseVTable;
-		private IntPtr m_pVTable = IntPtr.Zero;
-		private CCallbackBase m_CCallbackBase;
-		private GCHandle m_pCCallbackBase;
-
 		public delegate void APIDispatchDelegate(T param, bool bIOFailure);
 		private event APIDispatchDelegate m_Func;
 
 		private SteamAPICall_t m_hAPICall = SteamAPICall_t.Invalid;
 		public SteamAPICall_t Handle { get { return m_hAPICall; } }
-
-		private readonly int m_size = Marshal.SizeOf(typeof(T));
 
 		private bool m_bDisposed = false;
 
@@ -236,7 +278,6 @@ namespace Steamworks {
 
 		public CallResult(APIDispatchDelegate func = null) {
 			m_Func = func;
-			BuildCCallbackBase();
 		}
 
 		~CallResult() {
@@ -251,14 +292,6 @@ namespace Steamworks {
 			GC.SuppressFinalize(this);
 
 			Cancel();
-
-			if (m_pVTable != IntPtr.Zero) {
-				Marshal.FreeHGlobal(m_pVTable);
-			}
-
-			if (m_pCCallbackBase.IsAllocated) {
-				m_pCCallbackBase.Free();
-			}
 
 			m_bDisposed = true;
 		}
@@ -275,13 +308,13 @@ namespace Steamworks {
 			}
 
 			if (m_hAPICall != SteamAPICall_t.Invalid) {
-				NativeMethods.SteamAPI_UnregisterCallResult(m_pCCallbackBase.AddrOfPinnedObject(), (ulong)m_hAPICall);
+				CallbackDispatcher.Unregister(m_hAPICall, this);
 			}
 
 			m_hAPICall = hAPICall;
 
 			if (hAPICall != SteamAPICall_t.Invalid) {
-				NativeMethods.SteamAPI_RegisterCallResult(m_pCCallbackBase.AddrOfPinnedObject(), (ulong)hAPICall);
+				CallbackDispatcher.Register(hAPICall, this);
 			}
 		}
 
@@ -291,36 +324,16 @@ namespace Steamworks {
 
 		public void Cancel() {
 			if (m_hAPICall != SteamAPICall_t.Invalid) {
-				NativeMethods.SteamAPI_UnregisterCallResult(m_pCCallbackBase.AddrOfPinnedObject(), (ulong)m_hAPICall);
+				CallbackDispatcher.Unregister(m_hAPICall, this);
 				m_hAPICall = SteamAPICall_t.Invalid;
 			}
 		}
 
-		public void SetGameserverFlag() {
-			m_CCallbackBase.m_nCallbackFlags |= CCallbackBase.k_ECallbackFlagsGameServer;
+		internal override Type GetCallbackType() {
+			return typeof(T);
 		}
 
-		// Shouldn't ever get called here, but this is what C++ Steamworks does!
-		private void OnRunCallback(
-#if !STDCALL
-			IntPtr thisptr,
-#endif
-			IntPtr pvParam) {
-			m_hAPICall = SteamAPICall_t.Invalid; // Caller unregisters for us
-
-			try {
-				m_Func((T)Marshal.PtrToStructure(pvParam, typeof(T)), false);
-			}
-			catch (Exception e) {
-				CallbackDispatcher.ExceptionHandler(e);
-			}
-		}
-
-		private void OnRunCallResult(
-#if !STDCALL
-			IntPtr thisptr,
-#endif
-			IntPtr pvParam, bool bFailed, ulong hSteamAPICall_) {
+		internal override void OnRunCallResult(IntPtr pvParam, bool bFailed, ulong hSteamAPICall_) {
 			SteamAPICall_t hSteamAPICall = (SteamAPICall_t)hSteamAPICall_;
 			if (hSteamAPICall == m_hAPICall) {
 				m_hAPICall = SteamAPICall_t.Invalid; // Caller unregisters for us
@@ -333,87 +346,6 @@ namespace Steamworks {
 				}
 			}
 		}
-
-		private int OnGetCallbackSizeBytes(
-#if !STDCALL
-			IntPtr thisptr
-#endif
-			) {
-			return m_size;
-		}
-
-		// Steamworks.NET Specific
-		private void BuildCCallbackBase() {
-			m_CallbackBaseVTable = new CCallbackBaseVTable() {
-				m_RunCallback = OnRunCallback,
-				m_RunCallResult = OnRunCallResult,
-				m_GetCallbackSizeBytes = OnGetCallbackSizeBytes
-			};
-			m_pVTable = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(CCallbackBaseVTable)));
-			Marshal.StructureToPtr(m_CallbackBaseVTable, m_pVTable, false);
-
-			m_CCallbackBase = new CCallbackBase() {
-				m_vfptr = m_pVTable,
-				m_nCallbackFlags = 0,
-				m_iCallback = CallbackIdentities.GetCallbackIdentity(typeof(T))
-			};
-			m_pCCallbackBase = GCHandle.Alloc(m_CCallbackBase, GCHandleType.Pinned);
-		}
-	}
-
-	[StructLayout(LayoutKind.Sequential)]
-	internal class CCallbackBase {
-		public const byte k_ECallbackFlagsRegistered = 0x01;
-		public const byte k_ECallbackFlagsGameServer = 0x02;
-
-		public IntPtr m_vfptr;
-		public byte m_nCallbackFlags;
-		public int m_iCallback;
-	}
-
-	[StructLayout(LayoutKind.Sequential)]
-	internal class CCallbackBaseVTable {
-#if STDCALL
-		private const CallingConvention cc = CallingConvention.StdCall;
-
-		[UnmanagedFunctionPointer(cc)]
-		public delegate void RunCBDel(IntPtr pvParam);
-		[UnmanagedFunctionPointer(cc)]
-		public delegate void RunCRDel(IntPtr pvParam, [MarshalAs(UnmanagedType.I1)] bool bIOFailure, ulong hSteamAPICall);
-		[UnmanagedFunctionPointer(cc)]
-		public delegate int GetCallbackSizeBytesDel();
-#else
-	#if THISCALL
-		private const CallingConvention cc = CallingConvention.ThisCall;
-	#else
-		private const CallingConvention cc = CallingConvention.Cdecl;
-	#endif
-
-		[UnmanagedFunctionPointer(cc)]
-		public delegate void RunCBDel(IntPtr thisptr, IntPtr pvParam);
-		[UnmanagedFunctionPointer(cc)]
-		public delegate void RunCRDel(IntPtr thisptr, IntPtr pvParam, [MarshalAs(UnmanagedType.I1)] bool bIOFailure, ulong hSteamAPICall);
-		[UnmanagedFunctionPointer(cc)]
-		public delegate int GetCallbackSizeBytesDel(IntPtr thisptr);
-#endif
-
-		// RunCallback and RunCallResult are swapped in MSVC ABI
-#if WINDOWS_BUILD
-		[NonSerialized]
-		[MarshalAs(UnmanagedType.FunctionPtr)]
-		public RunCRDel m_RunCallResult;
-#endif
-		[NonSerialized]
-		[MarshalAs(UnmanagedType.FunctionPtr)]
-		public RunCBDel m_RunCallback;
-#if !WINDOWS_BUILD
-		[NonSerialized]
-		[MarshalAs(UnmanagedType.FunctionPtr)]
-		public RunCRDel m_RunCallResult;
-#endif
-		[NonSerialized]
-		[MarshalAs(UnmanagedType.FunctionPtr)]
-		public GetCallbackSizeBytesDel m_GetCallbackSizeBytes;
 	}
 }
 

--- a/Plugins/Steamworks.NET/CallbackDispatcher.cs
+++ b/Plugins/Steamworks.NET/CallbackDispatcher.cs
@@ -175,6 +175,7 @@ namespace Steamworks {
 				} finally {
 					NativeMethods.SteamAPI_ManualDispatch_FreeLastCallback(hSteamPipe);
 					foreach (var call in m_dispatchedApiCalls) {
+						m_registeredCallResults[call].SetUnregistered();
 						m_registeredCallResults.Remove(call);
 					}
 					m_dispatchedApiCalls.Clear();
@@ -345,10 +346,8 @@ namespace Steamworks {
 		}
 
 		public void Cancel() {
-			if (m_hAPICall != SteamAPICall_t.Invalid) {
+			if (IsActive())
 				CallbackDispatcher.Unregister(m_hAPICall, this);
-				m_hAPICall = SteamAPICall_t.Invalid;
-			}
 		}
 
 		internal override Type GetCallbackType() {
@@ -358,8 +357,6 @@ namespace Steamworks {
 		internal override void OnRunCallResult(IntPtr pvParam, bool bFailed, ulong hSteamAPICall_) {
 			SteamAPICall_t hSteamAPICall = (SteamAPICall_t)hSteamAPICall_;
 			if (hSteamAPICall == m_hAPICall) {
-				m_hAPICall = SteamAPICall_t.Invalid; // Caller unregisters for us
-
 				try {
 					m_Func((T)Marshal.PtrToStructure(pvParam, typeof(T)), bFailed);
 				}

--- a/Plugins/Steamworks.NET/CallbackDispatcher.cs
+++ b/Plugins/Steamworks.NET/CallbackDispatcher.cs
@@ -145,16 +145,13 @@ namespace Steamworks {
 						Marshal.PtrToStructure(m_callbackMsg.m_pubParam, callCompletedCb);
 						IntPtr pTmpCallResult = Marshal.AllocHGlobal(callCompletedCb.m_cubParam);
 						bool bFailed;
-						try {
-							if (NativeMethods.SteamAPI_ManualDispatch_GetAPICallResult(hSteamPipe, callCompletedCb.m_hAsyncCall, pTmpCallResult, callCompletedCb.m_cubParam, callCompletedCb.m_iCallback, out bFailed)) {
-								if (m_registeredCallResults.TryGetValue((ulong)callCompletedCb.m_hAsyncCall, out CallResult cr)) {
-									cr.OnRunCallResult(pTmpCallResult, bFailed, (ulong)callCompletedCb.m_hAsyncCall);
-								}
+						if (NativeMethods.SteamAPI_ManualDispatch_GetAPICallResult(hSteamPipe, callCompletedCb.m_hAsyncCall, pTmpCallResult, callCompletedCb.m_cubParam, callCompletedCb.m_iCallback, out bFailed)) {
+							if (m_registeredCallResults.TryGetValue((ulong)callCompletedCb.m_hAsyncCall, out CallResult cr)) {
+								cr.OnRunCallResult(pTmpCallResult, bFailed, (ulong)callCompletedCb.m_hAsyncCall);
 							}
-						} finally {
-							Marshal.FreeHGlobal(pTmpCallResult);
-							m_dispatchedApiCalls.Add((ulong)callCompletedCb.m_hAsyncCall);
 						}
+						Marshal.FreeHGlobal(pTmpCallResult);
+						m_dispatchedApiCalls.Add((ulong)callCompletedCb.m_hAsyncCall);
 					} else {
 						if (callbacksRegistry.TryGetValue(m_callbackMsg.m_iCallback, out var callbacks)) {
 							List<Callback> callbacksCopy;

--- a/Plugins/Steamworks.NET/Steam.cs
+++ b/Plugins/Steamworks.NET/Steam.cs
@@ -47,6 +47,9 @@ namespace Steamworks {
 				ret = CSteamAPIContext.Init();
 			}
 
+			if (ret)
+				CallbackDispatcher.Initialize();
+
 			return ret;
 		}
 
@@ -55,6 +58,7 @@ namespace Steamworks {
 			InteropHelp.TestIfPlatformSupported();
 			NativeMethods.SteamAPI_Shutdown();
 			CSteamAPIContext.Clear();
+			CallbackDispatcher.Shutdown();
 		}
 
 		// SteamAPI_RestartAppIfNecessary ensures that your executable was launched through Steam.
@@ -113,8 +117,7 @@ namespace Steamworks {
 		// One alternative is to call SteamAPI_RunCallbacks from the main thread only,
 		// and call SteamAPI_ReleaseCurrentThreadMemory regularly on other threads.
 		public static void RunCallbacks() {
-			InteropHelp.TestIfPlatformSupported();
-			NativeMethods.SteamAPI_RunCallbacks();
+			CallbackDispatcher.RunFrame(false);
 		}
 
 		//----------------------------------------------------------------------------------------------------------------------------------------------------------//
@@ -170,6 +173,9 @@ namespace Steamworks {
 				ret = CSteamGameServerAPIContext.Init();
 			}
 
+			if (ret)
+				CallbackDispatcher.Initialize();
+
 			return ret;
 		}
 
@@ -177,11 +183,11 @@ namespace Steamworks {
 			InteropHelp.TestIfPlatformSupported();
 			NativeMethods.SteamGameServer_Shutdown();
 			CSteamGameServerAPIContext.Clear();
+			CallbackDispatcher.Shutdown();
 		}
 
 		public static void RunCallbacks() {
-			InteropHelp.TestIfPlatformSupported();
-			NativeMethods.SteamGameServer_RunCallbacks();
+			CallbackDispatcher.RunFrame(true);
 		}
 
 		// Most Steam API functions allocate some amount of thread-local memory for

--- a/Plugins/Steamworks.NET/autogen/NativeMethods.cs
+++ b/Plugins/Steamworks.NET/autogen/NativeMethods.cs
@@ -121,6 +121,10 @@ namespace Steamworks {
 
 		[DllImport(NativeLibraryName, EntryPoint = "SteamAPI_ManualDispatch_FreeLastCallback", CallingConvention = CallingConvention.Cdecl)]
 		public static extern void SteamAPI_ManualDispatch_FreeLastCallback(HSteamPipe hSteamPipe);
+
+		[DllImport(NativeLibraryName, EntryPoin = "SteamAPI_ManualDispatch_GetAPICallResult", CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs(UnmanagedType.I1)]
+		public static extern bool SteamAPI_ManualDispatch_GetAPICallResult(HSteamPipe hSteamPipe, SteamAPICall_t hSteamAPICall, IntPtr pCallback, int cubCallback, int iCallbackExpected, out bool pbFailed);
 #endregion
 #region steam_gameserver.h
 		[DllImport(NativeLibraryName, EntryPoint = "SteamGameServer_InitSafe", CallingConvention = CallingConvention.Cdecl)]

--- a/Plugins/Steamworks.NET/autogen/NativeMethods.cs
+++ b/Plugins/Steamworks.NET/autogen/NativeMethods.cs
@@ -122,7 +122,7 @@ namespace Steamworks {
 		[DllImport(NativeLibraryName, EntryPoint = "SteamAPI_ManualDispatch_FreeLastCallback", CallingConvention = CallingConvention.Cdecl)]
 		public static extern void SteamAPI_ManualDispatch_FreeLastCallback(HSteamPipe hSteamPipe);
 
-		[DllImport(NativeLibraryName, EntryPoin = "SteamAPI_ManualDispatch_GetAPICallResult", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport(NativeLibraryName, EntryPoint = "SteamAPI_ManualDispatch_GetAPICallResult", CallingConvention = CallingConvention.Cdecl)]
 		[return: MarshalAs(UnmanagedType.I1)]
 		public static extern bool SteamAPI_ManualDispatch_GetAPICallResult(HSteamPipe hSteamPipe, SteamAPICall_t hSteamAPICall, IntPtr pCallback, int cubCallback, int iCallbackExpected, out bool pbFailed);
 #endregion


### PR DESCRIPTION
This PR implements the new manual dispatch system introduced in Steamworks SDK v1.48. Callback/CallResult interfaces remain the same as before.

Resolves #227

---

Previous questions:

- [x] Thread safety: it's possible for multiple threads to be registering callbacks. Currently using a single synchronization object, but seems like it could hold other threads up while callbacks are running, which leads into the next problem.
- [x] Registering new callbacks while callbacks are running: for workflows with many chained async actions, such as uploading UGC, it's likely for the dev to prepare the next stage within the current callback function. The current design may result in issues.
- [x] Registering multiple CallResults for the same SteamAPICall_t: Currently only one is allowed. Do we allow multiple CallResults to subscribe to the same SteamAPICall_t?
- [ ] Does the manual callback mechanism ever deinit? This needs some testing, since the docs isn't clear about what happens when you shut down the API.

Thinking more about synchronization, maybe the lock scope can be reduced to just while calling callbacks instead of around the entire RunFrame function, or the list can be duplicated before iterating. Other possible way is to put any newly registered items in a queue and processed when the next frame runs, but that sounds like it'll use a lot of extra space.