### PR TITLE
Update docs for AddRequestLobbyListFilterSlotsAvailable and GetNumLobbyMembers

### DIFF
--- a/Plugins/Steamworks.NET/autogen/isteammatchmaking.cs
+++ b/Plugins/Steamworks.NET/autogen/isteammatchmaking.cs
@@ -117,7 +117,7 @@ namespace Steamworks {
 		}
 
 		/// <summary>
-		/// <para> returns only lobbies with the specified number of slots available</para>
+		/// <para> returns only lobbies with AT LEAST the specified number of slots available</para>
 		/// </summary>
 		public static void AddRequestLobbyListFilterSlotsAvailable(int nSlotsAvailable) {
 			InteropHelp.TestIfAvailableClient();
@@ -203,8 +203,9 @@ namespace Steamworks {
 		}
 
 		/// <summary>
-		/// <para> Lobby iteration, for viewing details of users in a lobby</para>
-		/// <para> only accessible if the lobby user is a member of the specified lobby</para>
+		/// <para> Gets the number of users in a lobby.</para>
+        /// <para> Can be used for lobby iteration, for viewing details of users in a lobby</para>
+		/// <para> Steam IDs of other users are only accessible if the lobby user is a member of the specified lobby</para>
 		/// <para> persona information for other lobby members (name, avatar, etc.) will be asynchronously received</para>
 		/// <para> and accessible via ISteamFriends interface</para>
 		/// <para> returns the number of users in the specified lobby</para>


### PR DESCRIPTION
These docs were inaccurate. `GetNumLobbyMembers` can return the number of users without being a member of the Lobby, as shown in the official docs - https://partner.steamgames.com/doc/api/ISteamMatchmaking

Also, through testing I found that `AddRequestLobbyListFilterSlotsAvailable` will show rooms with more than the specified number available, so it is an "at least" filter.