### PR TITLE
Add if statement to SteamParamStringArray deconstructor

### DIFF
--- a/com.rlabrecque.steamworks.net/Runtime/InteropHelp.cs
+++ b/com.rlabrecque.steamworks.net/Runtime/InteropHelp.cs
@@ -149,9 +149,11 @@ namespace Steamworks {
 			}
 
 			~SteamParamStringArray() {
-				foreach (IntPtr ptr in m_Strings) {
-					Marshal.FreeHGlobal(ptr);
-				}
+				if (m_Strings != null) {
+					foreach (IntPtr ptr in m_Strings) {
+						Marshal.FreeHGlobal(ptr);
+					}
+                }
 
 				if (m_ptrStrings != IntPtr.Zero) {
 					Marshal.FreeHGlobal(m_ptrStrings);


### PR DESCRIPTION
I was having exceptions being thrown from this deconstructor, the easiest solution I saw was to add a null-check to prevent the iteration. 