### PR TITLE
Remove old Steam dlls in the root of the project

### DIFF
--- a/com.rlabrecque.steamworks.net/Editor/RedistCopy.cs
+++ b/com.rlabrecque.steamworks.net/Editor/RedistCopy.cs
@@ -8,6 +8,7 @@
 
 #if !DISABLESTEAMWORKS
 
+using UnityEngine;
 using UnityEditor;
 using UnityEditor.Callbacks;
 using System.IO;
@@ -16,32 +17,18 @@ using Steamworks;
 public class RedistCopy {
 	[PostProcessBuild]
 	public static void OnPostprocessBuild(BuildTarget target, string pathToBuiltProject) {
-		string baseDir;
-
-		switch(target)
-		{
-			case BuildTarget.StandaloneWindows:
-			{
-				baseDir = Path.Combine(Path.GetDirectoryName(pathToBuiltProject), Path.GetFileNameWithoutExtension(pathToBuiltProject) + "_Data");
-				break;
-			}
-			case BuildTarget.StandaloneWindows64:
-			{
-				baseDir = Path.Combine(Path.GetDirectoryName(pathToBuiltProject), Path.GetFileNameWithoutExtension(pathToBuiltProject) + "_Data");
-				break;
-			}
-			case BuildTarget.StandaloneLinux64:
-			{
-				baseDir = Path.Combine(Path.GetDirectoryName(pathToBuiltProject), Path.GetFileNameWithoutExtension(pathToBuiltProject) + "_Data");
-				break;
-			}
-			case BuildTarget.StandaloneOSX:
-			default:
-			{
-				return;
-			}
+		// We only want to do this on Steam supported platforms.
+		if ((target != BuildTarget.StandaloneWindows) && (target != BuildTarget.StandaloneWindows64) && (target != BuildTarget.StandaloneLinux64)) {
+			return;
 		}
 
+		CopyDebugInfo(target, pathToBuiltProject);
+
+		DeleteOldSteamApiDlls(target, pathToBuiltProject);
+	}
+
+	static void CopyDebugInfo(BuildTarget target, string pathToBuiltProject) {
+		string baseDir = Path.Combine(Path.GetDirectoryName(pathToBuiltProject), Path.GetFileNameWithoutExtension(pathToBuiltProject) + "_Data");
 		string pluginsDir = Path.Combine(baseDir, "Plugins");
 
 		// Create if it doesn't exist yet
@@ -59,6 +46,30 @@ public class RedistCopy {
 			""
 		};
 		File.WriteAllLines(Path.Combine(pluginsDir, "Steamworks.NET.txt"), DebugInfo);
+	}
+
+	static void DeleteOldSteamApiDlls(BuildTarget target, string pathToBuiltProject) {
+		string strDllPath = Path.Combine(pathToBuiltProject, "steam_api.dll");
+		if (File.Exists(strDllPath)) {
+			try {
+				File.Delete(strDllPath);
+			}
+			catch (System.Exception e) {
+				Debug.LogWarning($"[Steamworks.NET] Attempted to delete an old copy of 'steam_api.dll' in the following location: '{strDllPath}', but could not due to the following exception:");
+				Debug.LogException(e);
+			}
+		}
+
+		string strDll64Path = Path.Combine(pathToBuiltProject, "steam_api64.dll");
+		if (File.Exists(strDll64Path)) {
+			try {
+				File.Delete(strDll64Path);
+			}
+			catch (System.Exception e) {
+				Debug.LogWarning($"[Steamworks.NET] Attempted to delete an old copy of 'steam_api64.dll' in the following location: '{strDll64Path}', but could not due to the following exception:");
+				Debug.LogException(e);
+			}
+		}
 	}
 }
 

--- a/com.rlabrecque.steamworks.net/Editor/RedistInstall.cs
+++ b/com.rlabrecque.steamworks.net/Editor/RedistInstall.cs
@@ -11,30 +11,47 @@ using System.IO;
 public class RedistInstall {
 	static RedistInstall() {
 		WriteSteamAppIdTxtFile();
+
+		CheckForOldDlls();
 	}
 
 	static void WriteSteamAppIdTxtFile() {
-		string strCWD = Directory.GetCurrentDirectory();
-		string strDest = Path.Combine(strCWD, "steam_appid.txt");
+		string strCWDPath = Directory.GetCurrentDirectory();
+		string strSteamAppIdPath = Path.Combine(strCWDPath, "steam_appid.txt");
 
-		// If the steam_appid.txt file already exists, then we skip this!
-		if (File.Exists(strDest)) {
+		// If the steam_appid.txt file already exists, then there's nothing to do.
+		if (File.Exists(strSteamAppIdPath)) {
 			return;
 		}
 
 		Debug.Log("[Steamworks.NET] 'steam_appid.txt' is not present in the project root. Writing...");
 
-		try
-		{
-			StreamWriter appIdFile = File.CreateText(strDest);
+		try {
+			StreamWriter appIdFile = File.CreateText(strSteamAppIdPath);
 			appIdFile.Write("480");
 			appIdFile.Close();
 
-			Debug.Log("[Steamworks.NET] Successfully copied 'steam_appid.txt' into the project root. Please relaunch Unity.");
+			Debug.Log("[Steamworks.NET] Successfully copied 'steam_appid.txt' into the project root.");
 		}
 		catch (System.Exception e) {
 			Debug.LogWarning("[Steamworks.NET] Could not copy 'steam_appid.txt' into the project root. Please place 'steam_appid.txt' into the project root manually.");
 			Debug.LogException(e);
+		}
+	}
+
+	static void CheckForOldDlls() {
+		string strCwdPath = Directory.GetCurrentDirectory();
+
+		// Unfortunately we can't just delete these outright because Unity loads the dlls in the project root instantly and Windows won't let us delete them because they are in use.
+
+		string strDllPath = Path.Combine(strCwdPath, "steam_api.dll");
+		if (File.Exists(strDllPath)) {
+			Debug.LogError("[Steamworks.NET] Please delete the old version of 'steam_api.dll' in your project root before continuing.");
+		}
+
+		string strDll64Path = Path.Combine(strCwdPath, "steam_api64.dll");
+		if (File.Exists(strDll64Path)) {
+			Debug.LogError("[Steamworks.NET] Please delete the old version of 'steam_api64.dll' in your project root before continuing.");
 		}
 	}
 }


### PR DESCRIPTION
This should help assist in fixing a bunch of common issues where people have upgraded and still have an old version of steam_api[64].dll in their project root.

This just warns for the version which would get loaded in the editor, but forcefully trys to remove the version in the build output path for those that don't have any kind of cleaning of their output directory.

See also:
https://github.com/rlabrecque/Steamworks.NET/issues/373