### PR TITLE
feat: skip script symbols on other platforms

### DIFF
--- a/com.rlabrecque.steamworks.net/Editor/RedistInstall.cs
+++ b/com.rlabrecque.steamworks.net/Editor/RedistInstall.cs
@@ -57,6 +57,11 @@ public class RedistInstall {
 	}
 
 	static void AddDefineSymbols() {
+		if (EditorUserBuildSettings.selectedBuildTargetGroup != BuildTargetGroup.Standalone){
+			//Shouldn't add script defines for non-standalone platforms
+			return;
+		}
+  
 		string currentDefines = PlayerSettings.GetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup);
 		HashSet<string> defines = new HashSet<string>(currentDefines.Split(';')) {
 			"STEAMWORKS_NET"


### PR DESCRIPTION
On my current project we use Steam for standalone platforms, but the library is adding the scripting define on all platforms, leading to annoying git interactions