### PR TITLE
Removing UnityEngine reference inside com.rlabrecque.steamworks.net.asmdef

### DIFF
--- a/com.rlabrecque.steamworks.net/Runtime/CallbackDispatcher.cs
+++ b/com.rlabrecque.steamworks.net/Runtime/CallbackDispatcher.cs
@@ -34,10 +34,16 @@ namespace Steamworks {
 		// We catch exceptions inside callbacks and reroute them here.
 		// For some reason throwing an exception causes RunCallbacks() to break otherwise.
 		// If you have a custom ExceptionHandler in your engine you can register it here manually until we get something more elegant hooked up.
+
+		public delegate void OnSteamException(Exception e); 
+		public static OnSteamException OnSteamExceptionEvent; 
+
 		public static void ExceptionHandler(Exception e) {
-#if UNITY_STANDALONE
-			UnityEngine.Debug.LogException(e);
-#elif STEAMWORKS_WIN || STEAMWORKS_LIN_OSX
+			if(OnSteamExceptionEvent != null) {
+				OnSteamExceptionEvent.Invoke(e); 
+			}
+			
+#if STEAMWORKS_WIN || STEAMWORKS_LIN_OSX
 			Console.WriteLine(e.Message);
 #endif
 		}

--- a/com.rlabrecque.steamworks.net/Runtime/com.rlabrecque.steamworks.net.asmdef
+++ b/com.rlabrecque.steamworks.net/Runtime/com.rlabrecque.steamworks.net.asmdef
@@ -16,5 +16,5 @@
     "autoReferenced": true,
     "defineConstraints": [],
     "versionDefines": [],
-    "noEngineReferences": false
+    "noEngineReferences": true
 }


### PR DESCRIPTION
To improve compile times, I've removed the UnityEngine from the base of the plugin. The one reference was simply to pass along exception logging, so I've instead replaced it with a static delegate. In SteamManager.cs, you can hook into this delegate in OnEnable()/OnDisable().

I've attached some before and after examples of how compile times an be affected by this dependency chain change. 
![Unity_T36hsZdink](https://github.com/rlabrecque/Steamworks.NET/assets/3958573/85a90319-32b2-4a73-8e0d-7715b0277277)
![Unity_tFU2GfQlTM](https://github.com/rlabrecque/Steamworks.NET/assets/3958573/005140e4-0db1-4023-b066-f8739abd8aba)
