### PR TITLE
Fixing SteamInternal_GameServer_Init_V2

### DIFF
--- a/com.rlabrecque.steamworks.net/Runtime/Steam.cs
+++ b/com.rlabrecque.steamworks.net/Runtime/Steam.cs
@@ -12,6 +12,7 @@
 #if !DISABLESTEAMWORKS
 
 using System.Runtime.InteropServices;
+using System.Text;
 using IntPtr = System.IntPtr;
 
 namespace Steamworks {
@@ -59,7 +60,37 @@ namespace Steamworks {
 			InteropHelp.TestIfPlatformSupported();
 
 			IntPtr SteamErrorMsgPtr = Marshal.AllocHGlobal(Constants.k_cchMaxSteamErrMsg);
-			ESteamAPIInitResult initResult = NativeMethods.SteamInternal_SteamAPI_Init(IntPtr.Zero, SteamErrorMsgPtr);
+
+			StringBuilder sb = new StringBuilder();
+			sb.Append(Constants.STEAMUTILS_INTERFACE_VERSION).Append("\0");
+			sb.Append(Constants.STEAMNETWORKINGUTILS_INTERFACE_VERSION).Append("\0");
+			sb.Append(Constants.STEAMAPPS_INTERFACE_VERSION).Append("\0");
+			sb.Append(Constants.STEAMCONTROLLER_INTERFACE_VERSION).Append("\0");
+			sb.Append(Constants.STEAMFRIENDS_INTERFACE_VERSION).Append("\0");
+			sb.Append(Constants.STEAMGAMESEARCH_INTERFACE_VERSION).Append("\0");
+			sb.Append(Constants.STEAMHTMLSURFACE_INTERFACE_VERSION).Append("\0");
+			sb.Append(Constants.STEAMHTTP_INTERFACE_VERSION).Append("\0");
+			sb.Append(Constants.STEAMINPUT_INTERFACE_VERSION).Append("\0");
+			sb.Append(Constants.STEAMINVENTORY_INTERFACE_VERSION).Append("\0");
+			sb.Append(Constants.STEAMMATCHMAKINGSERVERS_INTERFACE_VERSION).Append("\0");
+			sb.Append(Constants.STEAMMATCHMAKING_INTERFACE_VERSION).Append("\0");
+			sb.Append(Constants.STEAMMUSICREMOTE_INTERFACE_VERSION).Append("\0");
+			sb.Append(Constants.STEAMMUSIC_INTERFACE_VERSION).Append("\0");
+			sb.Append(Constants.STEAMNETWORKINGMESSAGES_INTERFACE_VERSION).Append("\0");
+			sb.Append(Constants.STEAMNETWORKINGSOCKETS_INTERFACE_VERSION).Append("\0");
+			sb.Append(Constants.STEAMNETWORKING_INTERFACE_VERSION).Append("\0");
+			sb.Append(Constants.STEAMPARENTALSETTINGS_INTERFACE_VERSION).Append("\0");
+			sb.Append(Constants.STEAMPARTIES_INTERFACE_VERSION).Append("\0");
+			sb.Append(Constants.STEAMREMOTEPLAY_INTERFACE_VERSION).Append("\0");
+			sb.Append(Constants.STEAMREMOTESTORAGE_INTERFACE_VERSION).Append("\0");
+			sb.Append(Constants.STEAMSCREENSHOTS_INTERFACE_VERSION).Append("\0");
+			sb.Append(Constants.STEAMUGC_INTERFACE_VERSION).Append("\0");
+			sb.Append(Constants.STEAMUSERSTATS_INTERFACE_VERSION).Append("\0");
+			sb.Append(Constants.STEAMUSER_INTERFACE_VERSION).Append("\0");
+			sb.Append(Constants.STEAMVIDEO_INTERFACE_VERSION).Append("\0");
+			InteropHelp.UTF8StringHandle piciv = new InteropHelp.UTF8StringHandle(sb.ToString());
+			
+			ESteamAPIInitResult initResult = NativeMethods.SteamInternal_SteamAPI_Init(piciv, SteamErrorMsgPtr);
 			OutSteamErrMsg = InteropHelp.PtrToStringUTF8(SteamErrorMsgPtr);
 			Marshal.FreeHGlobal(SteamErrorMsgPtr);
 
@@ -201,10 +232,23 @@ namespace Steamworks {
 
 			using (var pchVersionString2 = new InteropHelp.UTF8StringHandle(pchVersionString)) {
 				IntPtr SteamErrorMsgPtr = Marshal.AllocHGlobal(Constants.k_cchMaxSteamErrMsg);
-				ESteamAPIInitResult initResult = NativeMethods.SteamInternal_GameServer_Init_V2(unIP, 0, usGamePort, usQueryPort, eServerMode, pchVersionString2, IntPtr.Zero, SteamErrorMsgPtr);
+				
+				var sb = new StringBuilder();
+				sb.Append(Constants.STEAMUTILS_INTERFACE_VERSION).Append('\0');
+				sb.Append(Constants.STEAMNETWORKINGUTILS_INTERFACE_VERSION).Append('\0');
+				sb.Append(Constants.STEAMGAMESERVER_INTERFACE_VERSION).Append('\0');
+				sb.Append(Constants.STEAMGAMESERVERSTATS_INTERFACE_VERSION).Append('\0');
+				sb.Append(Constants.STEAMHTTP_INTERFACE_VERSION).Append('\0');
+				sb.Append(Constants.STEAMINVENTORY_INTERFACE_VERSION).Append('\0');
+				sb.Append(Constants.STEAMNETWORKING_INTERFACE_VERSION).Append('\0');
+				sb.Append(Constants.STEAMNETWORKINGMESSAGES_INTERFACE_VERSION).Append('\0');
+				sb.Append(Constants.STEAMNETWORKINGSOCKETS_INTERFACE_VERSION).Append('\0');
+				sb.Append(Constants.STEAMUGC_INTERFACE_VERSION).Append('\0');
+				InteropHelp.UTF8StringHandle piciv = new InteropHelp.UTF8StringHandle(sb.ToString());
+				
+				ESteamAPIInitResult initResult = NativeMethods.SteamInternal_GameServer_Init_V2(unIP, usGamePort, usQueryPort, eServerMode, pchVersionString2, piciv, SteamErrorMsgPtr);
 				string SteamErrorMsg = InteropHelp.PtrToStringUTF8(SteamErrorMsgPtr);
 				Marshal.FreeHGlobal(SteamErrorMsgPtr);
-
 				if (initResult != ESteamAPIInitResult.k_ESteamAPIInitResult_OK)
 				{
 					return false;

--- a/com.rlabrecque.steamworks.net/Runtime/autogen/NativeMethods.cs
+++ b/com.rlabrecque.steamworks.net/Runtime/autogen/NativeMethods.cs
@@ -47,7 +47,7 @@ namespace Steamworks {
 
 #region steam_api.h
 		[DllImport(NativeLibraryName, EntryPoint = "SteamInternal_SteamAPI_Init", CallingConvention = CallingConvention.Cdecl)]
-		public static extern ESteamAPIInitResult SteamInternal_SteamAPI_Init(IntPtr pszInternalCheckInterfaceVersions, IntPtr pOutErrMsg);
+		public static extern ESteamAPIInitResult SteamInternal_SteamAPI_Init(InteropHelp.UTF8StringHandle pszInternalCheckInterfaceVersions, IntPtr pOutErrMsg);
 
 		[DllImport(NativeLibraryName, EntryPoint = "SteamAPI_Shutdown", CallingConvention = CallingConvention.Cdecl)]
 		public static extern void SteamAPI_Shutdown();
@@ -155,7 +155,7 @@ namespace Steamworks {
 		public static extern int SteamGameServer_GetHSteamUser();
 
 		[DllImport(NativeLibraryName, EntryPoint = "SteamInternal_GameServer_Init_V2", CallingConvention = CallingConvention.Cdecl)]
-		public static extern ESteamAPIInitResult SteamInternal_GameServer_Init_V2(uint unIP, ushort usPort, ushort usGamePort, ushort usQueryPort, EServerMode eServerMode, InteropHelp.UTF8StringHandle pchVersionString, IntPtr pszInternalCheckInterfaceVersions, IntPtr pOutErrMsg);
+		public static extern ESteamAPIInitResult SteamInternal_GameServer_Init_V2(uint unIP, ushort usGamePort, ushort usQueryPort, EServerMode eServerMode, InteropHelp.UTF8StringHandle pchVersionString, InteropHelp.UTF8StringHandle pszInternalCheckInterfaceVersions, IntPtr pOutErrMsg);
 #endregion
 #region SteamAPI Accessors
 		[DllImport(NativeLibraryName, EntryPoint = "SteamClient", CallingConvention = CallingConvention.Cdecl)]

--- a/com.rlabrecque.steamworks.net/Runtime/autogen/SteamConstants.cs
+++ b/com.rlabrecque.steamworks.net/Runtime/autogen/SteamConstants.cs
@@ -35,6 +35,7 @@ namespace Steamworks {
 		public const string STEAMMUSICREMOTE_INTERFACE_VERSION = "STEAMMUSICREMOTE_INTERFACE_VERSION001";
 		public const string STEAMNETWORKING_INTERFACE_VERSION = "SteamNetworking006";
 		public const string STEAMNETWORKINGMESSAGES_INTERFACE_VERSION = "SteamNetworkingMessages002";
+		public const string STEAMCONTROLLER_INTERFACE_VERSION = "SteamController008";
 		// Silence some warnings
 		public const string STEAMNETWORKINGSOCKETS_INTERFACE_VERSION = "SteamNetworkingSockets012";
 		// Silence some warnings


### PR DESCRIPTION
Closes #632 

The NativeMethods definition for `SteamInternal_GameServer_Init_V2` did not match the header file `steam_gameserver.h`. Because of this, the incorrect values were getting passed to the DLL, causing it to be impossible to start a GameServer. 

Furthermore, as mentioned in 632, the two Init methods now require proper version strings to be provided to them. This commit adds those version strings.