### PR TITLE
Add detailed logs if steam Init fails.

### DIFF
--- a/com.rlabrecque.steamworks.net/Runtime/Steam.cs
+++ b/com.rlabrecque.steamworks.net/Runtime/Steam.cs
@@ -56,6 +56,7 @@ namespace Steamworks {
 		// Returns true on success
 		public static ESteamAPIInitResult InitEx(out string OutSteamErrMsg)
 		{
+			OutSteamErrMsg = "";
 			InteropHelp.TestIfPlatformSupported();
 
 			var pszInternalCheckInterfaceVersions = new System.Text.StringBuilder();
@@ -260,7 +261,10 @@ namespace Steamworks {
 					}
 					else {
 						initResult = ESteamAPIInitResult.k_ESteamAPIInitResult_FailedGeneric;
-						OutSteamErrMsg = "[Steamworks.NET] Failed to initialize CSteamAPIContext";
+						if(!string.IsNullOrEmpty(OutSteamErrMsg))
+							OutSteamErrMsg = $"[Steamworks.NET] Failed to initialize CSteamAPIContext: {OutSteamErrMsg}";
+						else
+							OutSteamErrMsg = "[Steamworks.NET] Failed to initialize CSteamAPIContext";
 					}
 				}
 


### PR DESCRIPTION
The new InitEx method is awesome and provides much more data if something breaks. I've changed the method slightly to expose the underlying error that the Steam SDK produces instead of the generic Steamworks.NET error message.