### PR TITLE
Update RedistInstall.cs

### DIFF
--- a/com.rlabrecque.steamworks.net/Editor/RedistInstall.cs
+++ b/com.rlabrecque.steamworks.net/Editor/RedistInstall.cs
@@ -4,6 +4,7 @@
 
 using UnityEngine;
 using UnityEditor;
+using UnityEditor.Build;
 using System.IO;
 using System.Collections.Generic;
 


### PR DESCRIPTION
Regarding #654 

As discused in that issue,

However please note I tested this on Unity 2022 and found the same errors

```
Library\PackageCache\com.rlabrecque.steamworks.net@25d8e850d1\Editor\RedistInstall.cs(65,67): error CS0103: The name 'NamedBuildTarget' does not exist in the current context
```
and
```
Library\PackageCache\com.rlabrecque.steamworks.net@25d8e850d1\Editor\RedistInstall.cs(79,54): error CS0103: The name 'NamedBuildTarget' does not exist in the current context
```

So whatever caused this isn't Unity, it has to be some change to Steamworks.NET that was made in the past few days ... I didn't notice anything when I looked at the history of this file but I haven't looked to deeply past that.