### PR TITLE
Avoid adding the STEAMWORKS_NET define symbol to non-standalone platorms

### DIFF
--- a/com.rlabrecque.steamworks.net/Editor/RedistInstall.cs
+++ b/com.rlabrecque.steamworks.net/Editor/RedistInstall.cs
@@ -77,7 +77,7 @@ public class RedistInstall {
 #if DISABLESTEAMWORKS
         defines.Remove("STEAMWORKS_NET");
 #else
-		defines.Add("STEAMWORKS_NET");
+        defines.Add("STEAMWORKS_NET");
 #endif
 
         string newDefines = string.Join(";", defines);


### PR DESCRIPTION
Hi, I've added some logic to avoid the `STEAMWORKS_NET`  scripting define symbol being automatically added to unsupported platforms like Android, iOS, etc.

In these platforms, if `STEAMWORKS_NET` is found in the defines, it will be removed since it will not work anyway.
> In that case, because the console will already display a compiling error, you have to restart Unity in Non-SafeMode to the `STEAMWORKS_NET` to get automatically removed.

### Explanation:
In my case, I do not like spreading `#if  STEAMWORKS_NET` over my code base. I do it only in some special cases.

Scripts with a lot of Steam SDK library usage are part of an AssemblyDefinition like the one below:
![image](https://github.com/user-attachments/assets/b184aac8-0e66-4c25-b40f-a613be551e8a)


