### PR TITLE
Fix unsafe threaded access to callback registry

### DIFF
--- a/com.rlabrecque.steamworks.net/Runtime/CallbackDispatcher.cs
+++ b/com.rlabrecque.steamworks.net/Runtime/CallbackDispatcher.cs
@@ -181,12 +181,14 @@ namespace Steamworks {
 						}
 						Marshal.FreeHGlobal(pTmpCallResult);
 					} else {
-						List<Callback> callbacks;
-						if (callbacksRegistry.TryGetValue(callbackMsg.m_iCallback, out callbacks)) {
-							List<Callback> callbacksCopy;
-							lock (m_sync) {
+						List<Callback> callbacksCopy = null;
+						lock (m_sync) {
+							List<Callback> callbacks = null;
+							if (callbacksRegistry.TryGetValue(callbackMsg.m_iCallback, out callbacks)) {
 								callbacksCopy = new List<Callback>(callbacks);
 							}
+						}
+						if (callbacksCopy != null) {
 							foreach (var callback in callbacksCopy) {
 								callback.OnRunCallback(callbackMsg.m_pubParam);
 							}


### PR DESCRIPTION
Dictionary read happened without locking m_sync, which could cause reading the wrong callback list if it occurs during dictionary rehashing.