### PR TITLE
Add platform check to RedistInstall.cs

### DIFF
--- a/com.rlabrecque.steamworks.net/Editor/RedistInstall.cs
+++ b/com.rlabrecque.steamworks.net/Editor/RedistInstall.cs
@@ -12,6 +12,10 @@ using System.Collections.Generic;
 [InitializeOnLoad]
 public class RedistInstall {
 	static RedistInstall() {
+		// We only want to do this on Steam supported platforms.
+		if (EditorUserBuildSettings.selectedBuildTargetGroup != BuildTargetGroup.Standalone) {
+			return;
+		}
 		WriteSteamAppIdTxtFile();
 		AddDefineSymbols();
 		CheckForOldDlls();


### PR DESCRIPTION
This check:

https://github.com/khyperia/Steamworks.NET/blob/2ceddb2c35c88f069bbd8927b949a3d4eadb4e58/com.rlabrecque.steamworks.net/Editor/RedistCopy.cs#L20-L23

should be done in RedistInstall.cs as well: right now, the STEAMWORKS_NET define is getting added to every platform automatically. This is no good, it breaks stuff! It should not be added for non-Standalone (mac, win, linux) platforms.

(used selectedBuildTargetGroup because it's used again later in RedistInstall.cs, to add the STEAMWORKS_NET define)

(Thanks for your time, and thanks for making such a great library!)