### PR TITLE
Code change for PublishAot compliance

### DIFF
--- a/CodeGen/src/interfaces.py
+++ b/CodeGen/src/interfaces.py
@@ -718,8 +718,8 @@ def parse_func(f, interface, func):
         argnames += ")"
     elif func.returntype == "gameserveritem_t *":
         wrapperreturntype = "gameserveritem_t"
-        strReturnable += "(gameserveritem_t)Marshal.PtrToStructure("
-        argnames += "), typeof(gameserveritem_t)"
+        strReturnable += "Marshal.PtrToStructure<gameserveritem_t>("
+        argnames += "))"
     elif func.returntype == "CSteamID":
         wrapperreturntype = "CSteamID"
         strReturnable += "(CSteamID)"

--- a/CodeGen/templates/custom_types/SteamNetworkingTypes/SteamNetworkingMessage_t.cs
+++ b/CodeGen/templates/custom_types/SteamNetworkingTypes/SteamNetworkingMessage_t.cs
@@ -100,7 +100,7 @@ namespace Steamworks
 		/// Convert an IntPtr received from ISteamNetworkingSockets.ReceiveMessagesOnPollGroup into our structure.
 		/// This is a Steamworks.NET extension.
 		public static SteamNetworkingMessage_t FromIntPtr(IntPtr pointer) {
-			return (SteamNetworkingMessage_t)Marshal.PtrToStructure(pointer, typeof(SteamNetworkingMessage_t));
+			return Marshal.PtrToStructure<SteamNetworkingMessage_t>(pointer);
 		}
 	}
 }

--- a/com.rlabrecque.steamworks.net/Runtime/CallbackDispatcher.cs
+++ b/com.rlabrecque.steamworks.net/Runtime/CallbackDispatcher.cs
@@ -208,10 +208,7 @@ namespace Steamworks {
 		internal abstract void SetUnregistered();
 	}
 
-	public sealed class Callback<
-        [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]
-		T
-		> : Callback, IDisposable {
+	public sealed class Callback<T> : Callback, IDisposable {
 		public delegate void DispatchDelegate(T param);
 		private event DispatchDelegate m_Func;
 
@@ -309,10 +306,7 @@ namespace Steamworks {
 		internal abstract void SetUnregistered();
 	}
 
-	public sealed class CallResult<
-		[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]
-		T
-		> : CallResult, IDisposable {
+	public sealed class CallResult<T> : CallResult, IDisposable {
 		public delegate void APIDispatchDelegate(T param, bool bIOFailure);
 		private event APIDispatchDelegate m_Func;
 

--- a/com.rlabrecque.steamworks.net/Runtime/CallbackDispatcher.cs
+++ b/com.rlabrecque.steamworks.net/Runtime/CallbackDispatcher.cs
@@ -57,7 +57,7 @@ namespace Steamworks {
 			lock (m_sync) {
 				if (m_initCount == 0) {
 					NativeMethods.SteamAPI_ManualDispatch_Init();
-					m_pCallbackMsg = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(CallbackMsg_t)));
+					m_pCallbackMsg = Marshal.AllocHGlobal(Marshal.SizeOf<CallbackMsg_t>());
 				}
 				++m_initCount;
 			}
@@ -160,11 +160,11 @@ namespace Steamworks {
 			NativeMethods.SteamAPI_ManualDispatch_RunFrame(hSteamPipe);
 			var callbacksRegistry = isGameServer ? m_registeredGameServerCallbacks : m_registeredCallbacks;
 			while (NativeMethods.SteamAPI_ManualDispatch_GetNextCallback(hSteamPipe, m_pCallbackMsg)) {
-				CallbackMsg_t callbackMsg = (CallbackMsg_t)Marshal.PtrToStructure(m_pCallbackMsg, typeof(CallbackMsg_t));
+				CallbackMsg_t callbackMsg = Marshal.PtrToStructure<CallbackMsg_t>(m_pCallbackMsg);
 				try {
 					// Check for dispatching API call results
 					if (callbackMsg.m_iCallback == SteamAPICallCompleted_t.k_iCallback) {
-						SteamAPICallCompleted_t callCompletedCb = (SteamAPICallCompleted_t)Marshal.PtrToStructure(callbackMsg.m_pubParam, typeof(SteamAPICallCompleted_t));
+						SteamAPICallCompleted_t callCompletedCb = Marshal.PtrToStructure<SteamAPICallCompleted_t>(callbackMsg.m_pubParam);
 						IntPtr pTmpCallResult = Marshal.AllocHGlobal((int)callCompletedCb.m_cubParam);
 						bool bFailed;
 						if (NativeMethods.SteamAPI_ManualDispatch_GetAPICallResult(hSteamPipe, callCompletedCb.m_hAsyncCall, pTmpCallResult, (int)callCompletedCb.m_cubParam, callCompletedCb.m_iCallback, out bFailed)) {
@@ -181,14 +181,12 @@ namespace Steamworks {
 						}
 						Marshal.FreeHGlobal(pTmpCallResult);
 					} else {
-						List<Callback> callbacksCopy = null;
-						lock (m_sync) {
-							List<Callback> callbacks = null;
-							if (callbacksRegistry.TryGetValue(callbackMsg.m_iCallback, out callbacks)) {
+						List<Callback> callbacks;
+						if (callbacksRegistry.TryGetValue(callbackMsg.m_iCallback, out callbacks)) {
+							List<Callback> callbacksCopy;
+							lock (m_sync) {
 								callbacksCopy = new List<Callback>(callbacks);
 							}
-						}
-						if (callbacksCopy != null) {
 							foreach (var callback in callbacksCopy) {
 								callback.OnRunCallback(callbackMsg.m_pubParam);
 							}
@@ -210,7 +208,10 @@ namespace Steamworks {
 		internal abstract void SetUnregistered();
 	}
 
-	public sealed class Callback<T> : Callback, IDisposable {
+	public sealed class Callback<
+        [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]
+		T
+		> : Callback, IDisposable {
 		public delegate void DispatchDelegate(T param);
 		private event DispatchDelegate m_Func;
 
@@ -290,7 +291,7 @@ namespace Steamworks {
 
 		internal override void OnRunCallback(IntPtr pvParam) {
 			try {
-				m_Func((T)Marshal.PtrToStructure(pvParam, typeof(T)));
+				m_Func(Marshal.PtrToStructure<T>(pvParam));
 			}
 			catch (Exception e) {
 				CallbackDispatcher.ExceptionHandler(e);
@@ -308,7 +309,10 @@ namespace Steamworks {
 		internal abstract void SetUnregistered();
 	}
 
-	public sealed class CallResult<T> : CallResult, IDisposable {
+	public sealed class CallResult<
+		[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]
+		T
+		> : CallResult, IDisposable {
 		public delegate void APIDispatchDelegate(T param, bool bIOFailure);
 		private event APIDispatchDelegate m_Func;
 
@@ -385,7 +389,7 @@ namespace Steamworks {
 			SteamAPICall_t hSteamAPICall = (SteamAPICall_t)hSteamAPICall_;
 			if (hSteamAPICall == m_hAPICall) {
 				try {
-					m_Func((T)Marshal.PtrToStructure(pvParam, typeof(T)), bFailed);
+					m_Func(Marshal.PtrToStructure<T>(pvParam), bFailed);
 				}
 				catch (Exception e) {
 					CallbackDispatcher.ExceptionHandler(e);

--- a/com.rlabrecque.steamworks.net/Runtime/ISteamMatchmakingResponses.cs
+++ b/com.rlabrecque.steamworks.net/Runtime/ISteamMatchmakingResponses.cs
@@ -58,7 +58,7 @@ namespace Steamworks {
 				m_VTServerFailedToRespond = InternalOnServerFailedToRespond,
 				m_VTRefreshComplete = InternalOnRefreshComplete
 			};
-			m_pVTable = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(VTable)));
+			m_pVTable = Marshal.AllocHGlobal(Marshal.SizeOf<VTable>());
 			Marshal.StructureToPtr(m_VTable, m_pVTable, false);
 
 			m_pGCHandle = GCHandle.Alloc(m_pVTable, GCHandleType.Pinned);
@@ -204,7 +204,7 @@ namespace Steamworks {
 				m_VTServerResponded = InternalOnServerResponded,
 				m_VTServerFailedToRespond = InternalOnServerFailedToRespond,
 			};
-			m_pVTable = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(VTable)));
+			m_pVTable = Marshal.AllocHGlobal(Marshal.SizeOf<VTable>());
 			Marshal.StructureToPtr(m_VTable, m_pVTable, false);
 
 			m_pGCHandle = GCHandle.Alloc(m_pVTable, GCHandleType.Pinned);
@@ -303,7 +303,7 @@ namespace Steamworks {
 				m_VTPlayersFailedToRespond = InternalOnPlayersFailedToRespond,
 				m_VTPlayersRefreshComplete = InternalOnPlayersRefreshComplete
 			};
-			m_pVTable = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(VTable)));
+			m_pVTable = Marshal.AllocHGlobal(Marshal.SizeOf<VTable>());
 			Marshal.StructureToPtr(m_VTable, m_pVTable, false);
 
 			m_pGCHandle = GCHandle.Alloc(m_pVTable, GCHandleType.Pinned);
@@ -416,7 +416,7 @@ namespace Steamworks {
 				m_VTRulesFailedToRespond = InternalOnRulesFailedToRespond,
 				m_VTRulesRefreshComplete = InternalOnRulesRefreshComplete
 			};
-			m_pVTable = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(VTable)));
+			m_pVTable = Marshal.AllocHGlobal(Marshal.SizeOf<VTable>());
 			Marshal.StructureToPtr(m_VTable, m_pVTable, false);
 
 			m_pGCHandle = GCHandle.Alloc(m_pVTable, GCHandleType.Pinned);

--- a/com.rlabrecque.steamworks.net/Runtime/InteropHelp.cs
+++ b/com.rlabrecque.steamworks.net/Runtime/InteropHelp.cs
@@ -137,14 +137,14 @@ namespace Steamworks {
 					Marshal.Copy(strbuf, 0, m_Strings[i], strbuf.Length);
 				}
 
-				m_ptrStrings = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(IntPtr)) * m_Strings.Length);
+				m_ptrStrings = Marshal.AllocHGlobal(Marshal.SizeOf<IntPtr>() * m_Strings.Length);
 				SteamParamStringArray_t stringArray = new SteamParamStringArray_t() {
 					m_ppStrings = m_ptrStrings,
 					m_nNumStrings = m_Strings.Length
 				};
 				Marshal.Copy(m_Strings, 0, stringArray.m_ppStrings, m_Strings.Length);
 
-				m_pSteamParamStringArray = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(SteamParamStringArray_t)));
+				m_pSteamParamStringArray = Marshal.AllocHGlobal(Marshal.SizeOf<SteamParamStringArray_t>());
 				Marshal.StructureToPtr(stringArray, m_pSteamParamStringArray, false);
 			}
 
@@ -181,9 +181,9 @@ namespace Steamworks {
 				return;
 			}
 
-			int sizeOfMMKVP = Marshal.SizeOf(typeof(MatchMakingKeyValuePair_t));
+			int sizeOfMMKVP = Marshal.SizeOf<MatchMakingKeyValuePair_t>();
 
-			m_pNativeArray = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(IntPtr)) * filters.Length);
+			m_pNativeArray = Marshal.AllocHGlobal(Marshal.SizeOf<IntPtr>() * filters.Length);
 			m_pArrayEntries = Marshal.AllocHGlobal(sizeOfMMKVP * filters.Length);
 			for (int i = 0; i < filters.Length; ++i) {
 				Marshal.StructureToPtr(filters[i], new IntPtr(m_pArrayEntries.ToInt64() + (i * sizeOfMMKVP)), false);

--- a/com.rlabrecque.steamworks.net/Runtime/Packsize.cs
+++ b/com.rlabrecque.steamworks.net/Runtime/Packsize.cs
@@ -46,8 +46,8 @@ namespace Steamworks {
 #endif
 
 		public static bool Test() {
-			int sentinelSize = Marshal.SizeOf(typeof(ValvePackingSentinel_t));
-			int subscribedFilesSize = Marshal.SizeOf(typeof(RemoteStorageEnumerateUserSubscribedFilesResult_t));
+			int sentinelSize = Marshal.SizeOf<ValvePackingSentinel_t>();
+			int subscribedFilesSize = Marshal.SizeOf<RemoteStorageEnumerateUserSubscribedFilesResult_t>();
 #if VALVE_CALLBACK_PACK_LARGE
 			if (sentinelSize != 32 || subscribedFilesSize != (1 + 1 + 1 + 50 + 100) * 4 + 4)
 				return false;

--- a/com.rlabrecque.steamworks.net/Runtime/autogen/isteammatchmaking.cs
+++ b/com.rlabrecque.steamworks.net/Runtime/autogen/isteammatchmaking.cs
@@ -547,7 +547,7 @@ namespace Steamworks {
 		/// </summary>
 		public static gameserveritem_t GetServerDetails(HServerListRequest hRequest, int iServer) {
 			InteropHelp.TestIfAvailableClient();
-			return (gameserveritem_t)Marshal.PtrToStructure(NativeMethods.ISteamMatchmakingServers_GetServerDetails(CSteamAPIContext.GetSteamMatchmakingServers(), hRequest, iServer), typeof(gameserveritem_t));
+			return Marshal.PtrToStructure<gameserveritem_t>(NativeMethods.ISteamMatchmakingServers_GetServerDetails(CSteamAPIContext.GetSteamMatchmakingServers(), hRequest, iServer));
 		}
 
 		/// <summary>

--- a/com.rlabrecque.steamworks.net/Runtime/types/SteamNetworkingTypes/SteamNetworkingMessage_t.cs
+++ b/com.rlabrecque.steamworks.net/Runtime/types/SteamNetworkingTypes/SteamNetworkingMessage_t.cs
@@ -116,7 +116,7 @@ namespace Steamworks
 		/// Convert an IntPtr received from ISteamNetworkingSockets.ReceiveMessagesOnPollGroup into our structure.
 		/// This is a Steamworks.NET extension.
 		public static SteamNetworkingMessage_t FromIntPtr(IntPtr pointer) {
-			return (SteamNetworkingMessage_t)Marshal.PtrToStructure(pointer, typeof(SteamNetworkingMessage_t));
+			return Marshal.PtrToStructure<SteamNetworkingMessage_t>(pointer);
 		}
 	}
 }


### PR DESCRIPTION
This is a working copy to discuss #686

For now it has the functional changes required for the ```PublishAot``` compliance and fixes the IL warnings.

To be discussed:
- ```Marshal.SizeOf<T>()``` and ```Marshal.PtrToStructure<T>(IntPtr ptr)``` both require .NET 4.5.1 (netstandard 1.2)
- ```DynamicallyAccessedMembers``` requires .NET 5, and is not part of netstandard (which is not used by modern .NET platforms anymore)

For the standalone version, it is likely safe to switch the ```TargetFramework``` to ```net5.0```. It wouldn't change much of the current nuget coverage. It would remove support for pre-net6 mono/Xamarin (which are irrelevant since they are mobile targets), and the non-mobile targets would remain the same. Then it would be possible to add ```<IsAotCompatible>true</IsAotCompatible>```.

For the Unity version, the marshalling methods would require [Unity 5.6](https://docs.unity3d.com/560/Documentation/ScriptReference/ApiCompatibilityLevel.html) (aka 2017.0), which seems fine since [the Unity package targets 2019.4](https://github.com/rlabrecque/Steamworks.NET/blob/2ceddb2c35c88f069bbd8927b949a3d4eadb4e58/com.rlabrecque.steamworks.net/package.json#L5), but ```DynamicallyAccessedMembers``` will be a problem no matter which targeted Unity version because modern .NET 5+ is not supported at all. In this specific case it seems reasonable to have preprocessing switches around it.

For the old-school .NET 4.0 .csproj, if it desired to keep having it around (as I understand, it is there for users willing to compile an old-school lib from source, and it is not distributed in the nuget nor on the pre-built releases, right?), then preprocessing or proxy types would be required to keep it running.