### PR TITLE
Duplicate conditional in the csproj file for MacOS.

### DIFF
--- a/Standalone/Steamworks.NET.Standard.csproj
+++ b/Standalone/Steamworks.NET.Standard.csproj
@@ -59,7 +59,7 @@
 		<ErrorReport>prompt</ErrorReport>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'OSX-Linux|x64'">
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'OSX-Linux|arm64'">
 		<OutputPath>bin\arm64\OSX-Linux\</OutputPath>
 		<DefineConstants>TRACE;STEAMWORKS_LIN_OSX;STEAMWORKS_X64</DefineConstants>
 		<Optimize>true</Optimize>


### PR DESCRIPTION
At the request of @jolexxa and thanks to @khyperia for noticing this, I added **arm64**, instead of the duplicated x64 conditional to one of the property groups.

I think this should be it regarding getting things working on MacOS but if anyone notices anything else, feel free to poke me.