### PR TITLE
Added missing meta files

### DIFF
--- a/com.rlabrecque.steamworks.net/Runtime/types/SteamTimeline.meta
+++ b/com.rlabrecque.steamworks.net/Runtime/types/SteamTimeline.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b4c9878c08c8fce438ade50057725786
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.rlabrecque.steamworks.net/Runtime/types/SteamTimeline/TimelineEventHandle_t.cs.meta
+++ b/com.rlabrecque.steamworks.net/Runtime/types/SteamTimeline/TimelineEventHandle_t.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 19842a82d4c10684b827c101bf333151
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Your recent changes seem to have omitted the Unity meta files for the Timeline folder and type file so Unity will ignore them, causing a stream of errors for users using master.

I dropped it into Unity root and added those generated meta files so that should resolve the errors others are seeing, resolving issue #695 