### PR TITLE
Disable RedistInstall when DISABLESTEAMWORKS is defined

### DIFF
--- a/com.rlabrecque.steamworks.net/Editor/RedistInstall.cs
+++ b/com.rlabrecque.steamworks.net/Editor/RedistInstall.cs
@@ -2,6 +2,12 @@
 // Copyright (c) 2013-2022 Riley Labrecque
 // Please see the included LICENSE.txt for additional information.
 
+#if !(UNITY_STANDALONE_WIN || UNITY_STANDALONE_LINUX || UNITY_STANDALONE_OSX || STEAMWORKS_WIN || STEAMWORKS_LIN_OSX)
+#define DISABLESTEAMWORKS
+#endif
+
+#if !DISABLESTEAMWORKS
+
 using UnityEngine;
 using UnityEditor;
 using UnityEditor.Build;
@@ -88,3 +94,5 @@ public class RedistInstall {
         }
     }
 }
+
+#endif // !DISABLESTEAMWORKS


### PR DESCRIPTION
Right now, the `STEAMWORKS_NET` define is always added to the scripting defines.

If steamworks is disabled with `DISABLESTEAMWORKS` or because it isn't compatible with the platform, it should not be added.

Guards the file in constant bounds to check for the define.

Fixes #656 