### PR TITLE
Add setting to prevent Steamworks.NET from injecting define symbols

### DIFF
--- a/com.rlabrecque.steamworks.net/Editor/RedistInstall.cs
+++ b/com.rlabrecque.steamworks.net/Editor/RedistInstall.cs
@@ -66,6 +66,11 @@ public class RedistInstall {
 
     static void AddDefineSymbols()
     {
+	    if (!EditorSteamworksNETSettings.Instance.CanManageDefineSymbols)
+	    {
+		    return;
+	    }
+
         string currentDefines;
         HashSet<string> defines;
 

--- a/com.rlabrecque.steamworks.net/Editor/Settings.meta
+++ b/com.rlabrecque.steamworks.net/Editor/Settings.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1f8184d59cc54b41bd59665c1741eb93
+timeCreated: 1749166917

--- a/com.rlabrecque.steamworks.net/Editor/Settings/EditorSteamworksNETSettings.cs
+++ b/com.rlabrecque.steamworks.net/Editor/Settings/EditorSteamworksNETSettings.cs
@@ -1,0 +1,54 @@
+﻿using System.IO;
+using UnityEditor.Compilation;
+using UnityEngine;
+
+public sealed class EditorSteamworksNETSettings : ScriptableObject
+{
+    private const string FilePath = "ProjectSettings/SteamworksNETSettings.json";
+
+    [Tooltip("When enabled, the Steamworks.NET package will add the necessary define symbols to your project.")]
+    [SerializeField]
+    private bool canManageDefineSymbols = true;
+
+    public bool CanManageDefineSymbols
+    {
+        get => canManageDefineSymbols;
+
+        set
+        {
+            if (canManageDefineSymbols == value)
+            {
+                return;
+            }
+
+            canManageDefineSymbols = value;
+            Save();
+
+            if (canManageDefineSymbols)
+            {
+                // Reload domain to ensure that define symbols are applied correctly.
+                CompilationPipeline.RequestScriptCompilation();
+            }
+        }
+    }
+
+    /// <summary>
+    /// The instance of the SteamworksNETSettings class.
+    /// </summary>
+    public static EditorSteamworksNETSettings Instance
+    {
+        get
+        {
+            var json = File.Exists(FilePath) ? File.ReadAllText(FilePath) : "{}";
+            var settings = CreateInstance<EditorSteamworksNETSettings>();
+            JsonUtility.FromJsonOverwrite(json, settings);
+            return settings;
+        }
+    }
+
+    private void Save()
+    {
+        var jsonToSave = JsonUtility.ToJson(this, true);
+        File.WriteAllText(FilePath, jsonToSave);
+    }
+}

--- a/com.rlabrecque.steamworks.net/Editor/Settings/EditorSteamworksNETSettings.cs.meta
+++ b/com.rlabrecque.steamworks.net/Editor/Settings/EditorSteamworksNETSettings.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 405a05810d3640bf97990d1db61805f8
+timeCreated: 1749167443

--- a/com.rlabrecque.steamworks.net/Editor/Settings/EditorSteamworksNETSettingsElement.cs
+++ b/com.rlabrecque.steamworks.net/Editor/Settings/EditorSteamworksNETSettingsElement.cs
@@ -1,0 +1,90 @@
+﻿using System.IO;
+using UnityEditor;
+using UnityEngine.UIElements;
+
+public sealed class EditorSteamworksNETSettingsElement : VisualElement
+{
+    private readonly EditorSteamworksNETSettings _settings;
+
+    private const string UssFilePath =
+        "Packages/com.rlabrecque.steamworks.net/Editor/Settings/EditorSteamworksNETSettingsStyleSheet.uss";
+
+    public EditorSteamworksNETSettingsElement()
+    {
+        _settings = EditorSteamworksNETSettings.Instance;
+        var styleSheet = AssetDatabase.LoadAssetAtPath<StyleSheet>(UssFilePath);
+
+        if (styleSheet)
+        {
+            styleSheets.Add(styleSheet);
+        }
+        else
+        {
+            throw new FileNotFoundException($"File not found: {UssFilePath}");
+        }
+
+        var root = new VisualElement();
+        root.Add(CreateWindowTitleBar());
+        root.Add(CreateDefineSymbolsSection());
+        Add(root);
+    }
+
+    private static VisualElement CreateWindowTitleBar()
+    {
+        var titleBar = new VisualElement();
+        titleBar.AddToClassList("project-settings-title-bar");
+
+        var title = new Label { text = "Steamworks.NET Settings" };
+        title.AddToClassList("project-settings-title-bar__label");
+
+        titleBar.Add(title);
+        return titleBar;
+    }
+
+    private VisualElement CreateDefineSymbolsSection()
+    {
+        var toggleField = new Toggle("Can Manage the Define Symbols")
+        {
+            tooltip = "Set to true to allow Steamworks.NET to add define symbols in your project."
+        };
+
+        toggleField.SetValueWithoutNotify(_settings.CanManageDefineSymbols);
+        toggleField.RegisterValueChangedCallback(e => { _settings.CanManageDefineSymbols = e.newValue; });
+
+        const string Title = "Define Symbols";
+
+        const string Description =
+            "The Steamworks.NET package makes use of define symbols to enable or disable certain features. " +
+            "With this setting you can choose to let the package add these define symbols automatically or not." +
+            "The default value is true.";
+
+        return CreateSection(title: Title, description: Description, content: toggleField);
+    }
+
+    private static VisualElement CreateSection(string title, string description, VisualElement content)
+    {
+        var section = new VisualElement { name = "Section" };
+        section.AddToClassList("steamworks-section");
+
+        var sectionHeader = new Label { text = title };
+        sectionHeader.AddToClassList("steamworks-section__header");
+
+        var helpBox = new HelpBox();
+        helpBox.AddToClassList("steamworks-section__description");
+        var helpBoxIcon = new VisualElement();
+        helpBoxIcon.AddToClassList("unity-help-box__icon");
+        helpBoxIcon.AddToClassList("unity-help-box__icon--info");
+        var helpBoxLabel = new Label { text = description };
+        helpBoxLabel.AddToClassList("unity-help-box__label");
+        helpBox.Add(helpBoxIcon);
+        helpBox.Add(helpBoxLabel);
+
+        content.AddToClassList("steamworks-section__content");
+
+        section.Add(sectionHeader);
+        section.Add(helpBox);
+        section.Add(content);
+
+        return section;
+    }
+}

--- a/com.rlabrecque.steamworks.net/Editor/Settings/EditorSteamworksNETSettingsElement.cs
+++ b/com.rlabrecque.steamworks.net/Editor/Settings/EditorSteamworksNETSettingsElement.cs
@@ -55,7 +55,7 @@ public sealed class EditorSteamworksNETSettingsElement : VisualElement
 
         const string Description =
             "The Steamworks.NET package makes use of define symbols to enable or disable certain features. " +
-            "With this setting you can choose to let the package add these define symbols automatically or not." +
+            "With this setting you can choose to let the package add these define symbols automatically or not.\n" +
             "The default value is true.";
 
         return CreateSection(title: Title, description: Description, content: toggleField);

--- a/com.rlabrecque.steamworks.net/Editor/Settings/EditorSteamworksNETSettingsElement.cs.meta
+++ b/com.rlabrecque.steamworks.net/Editor/Settings/EditorSteamworksNETSettingsElement.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 18f5fde747c54d00a38f482196793f28
+timeCreated: 1749167285

--- a/com.rlabrecque.steamworks.net/Editor/Settings/EditorSteamworksNETSettingsProvider.cs
+++ b/com.rlabrecque.steamworks.net/Editor/Settings/EditorSteamworksNETSettingsProvider.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine.UIElements;
+
+public sealed class EditorSteamworksNETSettingsProvider : SettingsProvider
+{
+    private const string SettingsPath = "Project/Steamworks.NET";
+
+    private EditorSteamworksNETSettingsProvider(SettingsScope scopes, IEnumerable<string> keywords = null)
+        : base(SettingsPath, scopes, keywords)
+    {
+    }
+
+    public override void OnActivate(string searchContext, VisualElement rootElement)
+    {
+        base.OnActivate(searchContext, rootElement);
+        rootElement.Add(new EditorSteamworksNETSettingsElement());
+    }
+
+    /// <summary>
+    /// Method which adds your settings provider to ProjectSettings
+    /// </summary>
+    /// <returns>A <see cref="EditorSteamworksNETSettingsProvider"/>.</returns>
+    [SettingsProvider]
+    public static SettingsProvider CreateSettingsProvider()
+    {
+        return new EditorSteamworksNETSettingsProvider(SettingsScope.Project);
+    }
+}

--- a/com.rlabrecque.steamworks.net/Editor/Settings/EditorSteamworksNETSettingsProvider.cs.meta
+++ b/com.rlabrecque.steamworks.net/Editor/Settings/EditorSteamworksNETSettingsProvider.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 943edff1c475473296ce0569c182d86a
+timeCreated: 1749166940

--- a/com.rlabrecque.steamworks.net/Editor/Settings/EditorSteamworksNETSettingsStyleSheet.uss
+++ b/com.rlabrecque.steamworks.net/Editor/Settings/EditorSteamworksNETSettingsStyleSheet.uss
@@ -1,0 +1,22 @@
+.steamworks-section {
+    background-color: #424242;
+    border-color: #191919;
+    border-width: 1px;
+    padding: 5px;
+    margin: 5px;
+}
+
+.steamworks-section__header {
+    font-size: 16px;
+    -unity-font-style: bold;
+    margin-bottom: 5px;
+}
+
+.steamworks-section__description {
+    margin-bottom: 5px;
+}
+
+.steamworks-section__content {
+    margin-left: 10px;
+    margin-bottom: 5px;
+}

--- a/com.rlabrecque.steamworks.net/Editor/Settings/EditorSteamworksNETSettingsStyleSheet.uss.meta
+++ b/com.rlabrecque.steamworks.net/Editor/Settings/EditorSteamworksNETSettingsStyleSheet.uss.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fcba6a16ac8056e418e5f791a8bbb67c
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0


### PR DESCRIPTION
Hi everyone! 👋

I just created a simple settings menu and wanted to share it here in case you're interested in merging it.

When building the game for platforms other than Steam (like Epic Games), we don’t want to include the Steamworks.NET SDK. However, the `RedistInstall` class keeps automatically adding the `STEAMWORKS_NET` define symbol to the project, which makes this tricky.

This hasn’t been a big issue in the past, but now that I’m integrating Epic Online Services SDK, I need more flexibility to build for either Steam or Epic. I’m planning to handle that using Unity’s new Build Profiles, which allow me to define platform-specific scripting symbols.

With this new settings option, we can **disable the automatic addition of** `STEAMWORKS_NET`, giving us full control per build profile. For example, I can enable the symbol only in my Steam profile, and everything works smoothly. ✅

Let me know what you think!

## 🔧 How the settings option works
A configuration file is created at:
```
ProjectSettings/SteamworksNETSettings.json
```
This file stores the flag value for disabling the automatic `STEAMWORKS_NET` define symbol. It also serves as a central place to store any other Steamworks.NET-related settings in the future.

> 1) The file is created only if you disable the flag at least once
> 2) When enabling it again from the disabled state, it will trigger the Domain Reload so the `RedistInstall` can run and add it automatically again.

This makes it easy to persist and share the configuration across team members and CI setups.

![image](https://github.com/user-attachments/assets/135cb346-5dc8-413f-8460-dbc66e3f5eae)
