### PR TITLE
fix : error "Callback dispatcher is not initialized."

### DIFF
--- a/com.rlabrecque.steamworks.net/Runtime/CallbackDispatcher.cs
+++ b/com.rlabrecque.steamworks.net/Runtime/CallbackDispatcher.cs
@@ -49,6 +49,15 @@ namespace Steamworks {
 		private static IntPtr m_pCallbackMsg;
 		private static int m_initCount;
 
+		#if UNITY_2019_3_OR_NEWER
+		// In case of disabled Domain Reload, reset static members before entering Play Mode.
+		[RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+		private static void InitOnPlayMode()
+		{
+			m_initCount = 0;
+		}
+		#endif
+
 		public static bool IsInitialized {
 			get { return m_initCount > 0; }
 		}


### PR DESCRIPTION
in Unity, [Disabled Domain Reload] cause a value still keeping in static variable "m_initCount".
when enter Play Mode for a second time after re-compiled, It output a ton of error in Unity debug log.

It's small change to clear this value before entering Play Mode. I copied code snippet from SteamManager.cs