### PR TITLE
Fix union: replace managed array with fixed size struct in `ReceivedRelayAuthTicket.ExtraField.OptionValue`

### DIFF
--- a/CodeGen/templates/custom_types/SteamDatagramTickets/SteamDatagramRelayAuthTicket.cs
+++ b/CodeGen/templates/custom_types/SteamDatagramTickets/SteamDatagramRelayAuthTicket.cs
@@ -94,13 +94,13 @@ namespace Steamworks
 
 			[MarshalAs(UnmanagedType.ByValArray, SizeConst = 28)]
 			byte[] m_szName;
-
+			[StructLayout(LayoutKind.Sequential, Size = 128)]
+			public struct FixedBytes128 { }
 			[StructLayout(LayoutKind.Explicit)]
 			struct OptionValue
 			{
 				[FieldOffset(0)]
-				[MarshalAs(UnmanagedType.ByValArray, SizeConst = 128)]
-				byte[] m_szStringValue;
+				public FixedBytes128 m_szStringValue;
 
 				[FieldOffset(0)]
 				long m_nIntValue;


### PR DESCRIPTION
Hello, sorry this is my first PR, apologies if I did things wrong.
This PR should fix a crash that occurs when calling `ReceivedRelayAuthTicket`.
Fixes #740