### PR TITLE
Assembly Definition Define Constraints & Load Stylesheet by Guid...

### DIFF
--- a/com.rlabrecque.steamworks.net/Editor/Settings/EditorSteamworksNETSettingsElement.cs
+++ b/com.rlabrecque.steamworks.net/Editor/Settings/EditorSteamworksNETSettingsElement.cs
@@ -8,11 +8,13 @@ public sealed class EditorSteamworksNETSettingsElement : VisualElement
 
     private const string UssFilePath =
         "Packages/com.rlabrecque.steamworks.net/Editor/Settings/EditorSteamworksNETSettingsStyleSheet.uss";
+    private const string UssFileGuid = "fcba6a16ac8056e418e5f791a8bbb67c";
 
     public EditorSteamworksNETSettingsElement()
     {
         _settings = EditorSteamworksNETSettings.Instance;
-        var styleSheet = AssetDatabase.LoadAssetAtPath<StyleSheet>(UssFilePath);
+        //var styleSheet = AssetDatabase.LoadAssetAtPath<StyleSheet>(UssFilePath);
+        var styleSheet = AssetDatabase.LoadAssetAtPath<StyleSheet>(AssetDatabase.GUIDToAssetPath(UssFileGuid));
 
         if (styleSheet)
         {

--- a/com.rlabrecque.steamworks.net/Editor/com.rlabrecque.steamworks.net.editor.asmdef
+++ b/com.rlabrecque.steamworks.net/Editor/com.rlabrecque.steamworks.net.editor.asmdef
@@ -12,7 +12,9 @@
     "overrideReferences": true,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": [],
+    "defineConstraints": [
+        "UNITY_EDITOR"
+    ],
     "versionDefines": [],
     "noEngineReferences": false
 }

--- a/com.rlabrecque.steamworks.net/Runtime/com.rlabrecque.steamworks.net.asmdef
+++ b/com.rlabrecque.steamworks.net/Runtime/com.rlabrecque.steamworks.net.asmdef
@@ -14,7 +14,9 @@
     "overrideReferences": true,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": [],
+    "defineConstraints": [
+        "UNITY_EDITOR || STEAMWORKS_NET"
+    ],
     "versionDefines": [],
     "noEngineReferences": false
 }


### PR DESCRIPTION
Small update that does 2 main things:

1) sets define constraints in both the assembly definitions so that the assemblies are fully ignored based on the STEAMWORKS_NET define OR if in UNITY_EDITOR. This way the assembly is completely ignored even if you're on a supported platform in scenarios you're not building for steam (such as an itch.io or GoG build).

2) changed EditorSteamworksNETSettingsElement to load the stylesheet using the 'guid' so that it is folder agnostic of the 'Packages' folder. This way even if you have Steamworks.Net in your project Assets folder, rather than via the package manager, the UI still works.