### PR TITLE
Fixed bug where m_initCount was set to 0 after initialization

### DIFF
--- a/com.rlabrecque.steamworks.net/Runtime/CallbackDispatcher.cs
+++ b/com.rlabrecque.steamworks.net/Runtime/CallbackDispatcher.cs
@@ -61,14 +61,19 @@ namespace Steamworks {
 		private static IntPtr m_pCallbackMsg;
 		private static int m_initCount;
 
-		#if UNITY_2019_3_OR_NEWER
-		// In case of disabled Domain Reload, reset static members before entering Play Mode.
-		[UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeLoadType.SubsystemRegistration)]
-		private static void InitOnPlayMode()
-		{
-			m_initCount = 0;
-		}
-		#endif
+        #if UNITY_2019_3_OR_NEWER && UNITY_EDITOR
+        // In case of disabled Domain Reload, reset static members before entering Play Mode.
+        [UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeLoadType.SubsystemRegistration)]
+        private static void InitOnPlayMode()
+        {
+            var hasDomainReloadDisabled = UnityEditor.EditorSettings.enterPlayModeOptionsEnabled &&
+                                          UnityEditor.EditorSettings.enterPlayModeOptions.HasFlag(UnityEditor.EnterPlayModeOptions.DisableDomainReload);
+            if (hasDomainReloadDisabled)
+            {
+                m_initCount = 0;
+            }
+        }
+        #endif
 
 		public static bool IsInitialized {
 			get { return m_initCount > 0; }


### PR DESCRIPTION
Just encountered a bug where I was calling SteamAPI.Init() in RuntimeInitializeLoadType.AfterAssembliesLoaded, and InitOnPlayMode ended up overwriting the m_initCount value, despite it being in a build and me not having domain reload on. 

This PR essentially just ensures it only tries to do it in editor, and I added some code to ensure it only happens if the developer has DisableDomainReload enabled, since that's the purpose that was listed in the comment.