### PR TITLE
Fix Android ARM64 plugin import in Unity 2022

### DIFF
--- a/com.rlabrecque.steamworks.net/Plugins/androidarm64/libsteam_api.so.meta
+++ b/com.rlabrecque.steamworks.net/Plugins/androidarm64/libsteam_api.so.meta
@@ -2,7 +2,7 @@ fileFormatVersion: 2
 guid: b5b80256302824d4a99b5ac1ba267d62
 PluginImporter:
   externalObjects: {}
-  serializedVersion: 3
+  serializedVersion: 2
   iconMap: {}
   executionOrder: {}
   defineConstraints: []
@@ -11,14 +11,9 @@ PluginImporter:
   isExplicitlyReferenced: 0
   validateReferences: 1
   platformData:
-    Android:
-      enabled: 1
-      settings:
-        AndroidLibraryDependee: UnityLibrary
-        AndroidSharedLibraryType: Executable
-        CPU: ARM64
-        Is16KbAligned: false
-    Any:
+  - first:
+      : Any
+    second:
       enabled: 0
       settings:
         Exclude Android: 0
@@ -27,25 +22,49 @@ PluginImporter:
         Exclude OSXUniversal: 1
         Exclude Win: 1
         Exclude Win64: 1
-    Editor:
+  - first:
+      Android: Android
+    second:
+      enabled: 1
+      settings:
+        AndroidLibraryDependee: UnityLibrary
+        AndroidSharedLibraryType: Executable
+        CPU: ARM64
+        Is16KbAligned: true
+  - first:
+      Any:
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
       enabled: 0
       settings:
         CPU: AnyCPU
         DefaultValueInitialized: true
         OS: AnyOS
-    Linux64:
+  - first:
+      Standalone: Linux64
+    second:
       enabled: 0
       settings:
         CPU: None
-    OSXUniversal:
+  - first:
+      Standalone: OSXUniversal
+    second:
       enabled: 0
       settings:
         CPU: None
-    Win:
+  - first:
+      Standalone: Win
+    second:
       enabled: 0
       settings:
         CPU: None
-    Win64:
+  - first:
+      Standalone: Win64
+    second:
       enabled: 0
       settings:
         CPU: None


### PR DESCRIPTION
## What changed

Serialize the Android ARM64 `libsteam_api.so` importer settings using the version-2 `PluginImporter.platformData` list format supported by Unity 2019–2022, while retaining Android/ARM64 compatibility and marking the Steamworks SDK 1.64 binary as 16 KB aligned.

## Root cause

The existing version-3 dictionary-form metadata is imported by Unity 2022.3, but its Android compatibility settings are not applied. Unity silently omits `libsteam_api.so` from the generated Gradle project's `jniLibs` directory.

Open Brush CI on Unity 2022.3.62f2 demonstrated the failure with both Steamworks.NET 2025.163.0 and current master: the asset import was logged, but no native `CopyFiles` operation occurred and the resulting APK lacked the library.

## Validation

Open Brush CI run: https://github.com/icosa-foundation/open-brush/actions/runs/29528879632

The Android OpenXR job now logs:

```
CopyFiles .../Gradle/unityLibrary/src/main/jniLibs/arm64-v8a/libsteam_api.so
```

The downloaded APK contains:

```
lib/arm64-v8a/libsteam_api.so
```

`readelf -lW` reports `0x4000` alignment for every ELF `LOAD` segment in the Steamworks SDK 1.64 binary.

Related: #776